### PR TITLE
Update dependent subprojects example to remove afterEvaluate

### DIFF
--- a/src/integration-test/examples/dependent-subprojects/dependent/build.gradle
+++ b/src/integration-test/examples/dependent-subprojects/dependent/build.gradle
@@ -21,6 +21,4 @@ dockerAlfresco {
     }
 }
 
-afterEvaluate {
-    createDockerFile.dependsOn(':baseImage:buildLabels')
-}
+createDockerFile.dependsOn(':baseImage:buildDockerImage')


### PR DESCRIPTION
afterEvaluate is no longer needed, as the createDockerFile task is available immediately.
The buildLabels task is also deprecated, so we should no longer point people to it