### PR TITLE
WIP: Make MergeWarTask extend the Zip task

### DIFF
--- a/src/main/java/eu/xenit/gradle/tasks/InjectFilesInWarTask.java
+++ b/src/main/java/eu/xenit/gradle/tasks/InjectFilesInWarTask.java
@@ -57,11 +57,6 @@ public class InjectFilesInWarTask extends DefaultTask implements WarEnrichmentTa
         return outputWar.get();
     }
 
-    @Override
-    public void setOutputWar(Supplier<File> outputWar) {
-        this.outputWar = outputWar;
-    }
-
     @InputFiles
     public Set<File> getSourceFiles()
     {

--- a/src/main/java/eu/xenit/gradle/tasks/MergeWarsTask.java
+++ b/src/main/java/eu/xenit/gradle/tasks/MergeWarsTask.java
@@ -1,22 +1,20 @@
 package eu.xenit.gradle.tasks;
 
-import de.schlichtherle.truezip.file.TFile;
-import org.gradle.api.DefaultTask;
-import org.gradle.api.tasks.*;
-
 import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import org.gradle.api.file.CopySpec;
+import org.gradle.api.file.FileTree;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.bundling.Zip;
 
-public class MergeWarsTask extends DefaultTask implements LabelConsumerTask, WarLabelOutputTask {
-    /**
-     * WAR files used as input (are not modified)
-     *
-     * Later files overwrite earlier files
-     */
-    private Supplier<List<File>> inputWars;
+public class MergeWarsTask extends Zip implements LabelConsumerTask, WarLabelOutputTask {
 
     /**
      * WAR file used as output (is created from inputWar)
@@ -24,6 +22,17 @@ public class MergeWarsTask extends DefaultTask implements LabelConsumerTask, War
     private Supplier<File> outputWar = () -> { return getProject().getBuildDir().toPath().resolve("xenit-gradle-plugins").resolve(getName()).resolve(getName()+".war").toFile(); };
 
     private List<Supplier<Map<String, String>>> labels = new ArrayList<>();
+
+    private final CopySpec childWars;
+
+    public MergeWarsTask() {
+        super();
+        setExtension("war");
+        setDestinationDir(
+                getProject().getBuildDir().toPath().resolve("xenit-gradle-plugins").resolve(getName()).toFile());
+        setBaseName(getName());
+        childWars = getRootSpec().addChildBeforeSpec(getMainSpec());
+    }
 
     @Override
     public void withLabels(Supplier<Map<String, String>> labels) {
@@ -40,39 +49,22 @@ public class MergeWarsTask extends DefaultTask implements LabelConsumerTask, War
         return accumulator;
     }
 
-    @InputFiles
-    public List<File> getInputWars() {
-        return inputWars.get();
-    }
-
+    /**
+     * WAR files used as input (are not modified)
+     * <p>
+     * Later files overwrite earlier files
+     */
     public void setInputWars(Supplier<List<File>> inputWars) {
-        this.inputWars = inputWars;
+        childWars.from((Callable<List<FileTree>>) () -> inputWars.get()
+                .stream()
+                .map(war -> getProject().zipTree(war))
+                .collect(Collectors.toList()));
     }
 
     @Override
     @OutputFile
     public File getOutputWar() {
-        return outputWar.get();
-    }
-
-    @Override
-    public void setOutputWar(Supplier<File> outputWar) {
-        this.outputWar = outputWar;
-    }
-
-    @TaskAction
-    public void stripWar() {
-        for(File file: getInputWars()) {
-            Util.withWar(file, inputWar -> {
-                Util.withWar(getOutputWar(), outputWar -> {
-                    try {
-                        TFile.cp_rp(inputWar, outputWar, inputWar.getArchiveDetector(), outputWar.getArchiveDetector());
-                    } catch (IOException e) {
-                        throw new UncheckedIOException(e);
-                    }
-                });
-            });
-        }
+        return getDestinationDir().toPath().resolve(getName()).toFile();
     }
 
 }

--- a/src/main/java/eu/xenit/gradle/tasks/ResolveWarTask.java
+++ b/src/main/java/eu/xenit/gradle/tasks/ResolveWarTask.java
@@ -47,11 +47,6 @@ public class ResolveWarTask extends DefaultTask implements WarEnrichmentTask {
     }
 
     @Override
-    public void setOutputWar(Supplier<File> outputWar) {
-        throw new UnsupportedOperationException("outputWar is required to be the same as inputWar");
-    }
-
-    @Override
     public void withLabels(Supplier<Map<String, String>> labels) {
         this.labels.add(labels);
     }

--- a/src/main/java/eu/xenit/gradle/tasks/WarOutputTask.java
+++ b/src/main/java/eu/xenit/gradle/tasks/WarOutputTask.java
@@ -1,24 +1,11 @@
 package eu.xenit.gradle.tasks;
 
-import groovy.lang.Closure;
 import org.gradle.api.Task;
 import org.gradle.api.tasks.OutputFile;
 
 import java.io.File;
-import java.util.function.Supplier;
 
 public interface WarOutputTask extends Task {
     @OutputFile
     File getOutputWar();
-
-    void setOutputWar(Supplier<File> outputWar);
-
-    default void setOutputWar(Closure<File> outputWar) {
-        setOutputWar(() -> outputWar.call());
-    }
-
-    default void setOutputWar(File outputWar) {
-        setOutputWar(() -> outputWar);
-    }
-
 }


### PR DESCRIPTION
To make it easier to publish alfresco/share war as artifact, I made it extend the `Zip` task.

However, this change makes it difficult to keep supporting the `setOutputWar()` method to choose where you want to place the output war.
It also changes the location in the build directory where the output war is located by default.

Given that the `MergeWarTask` was not part of the documented public API, we should be able to change it in a minor release.

This change will also make the `mergeAlfrescoWar` and `mergeShareWar` tasks part of the public API, and they should be documented as a way to publish the generated wars.

Publishing can be achieved with:
```gradle
publishing {
    publications {
        alfrescoWar(MavenPublication) {
            artifactId "alfresco"
            artifact mergeAlfrescoWar
        }

        shareWar(MavenPublication) {
            artifactId "share"
            artifact mergeShareWar
        }
    }
}
```

It is required to create two different publications and set the `artifactId` for each one since the alfresco and share war have the same type and classifier and would overwrite each other if they did not have a different artifact id.

They would be referred to from other projects like `groupname:alfresco:version@war` and `groupname:share:version@war`

An other possibility is to set the classifier on one or both of the `MergeWarTask`s

```gradle
mergeAlfrescoWar {
   classifier "alfresco"
}
mergeShareWar {
    classifier "share"
}
publishing {
    publications {
        wars(MavenPublication) {
            artifact mergeAlfrescoWar
            artifact mergeShareWar
        }
    }
}
```

This will make both artifacts share the same pom and forces them to have the same version.
They would be referred to from other projects like `groupname:projectname:version:alfresco@war` and `groupname:projectname:version:share@war`