### PR TITLE
DEVEM-342 fixes failing composeUp with warnings on stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # XeniT Gradle Plugin - Changelog
 
+## Version 4.0.3 - (Unreleased)
+
+### Fixes
+
+ * [DEVEM-342](https://xenitsupport.jira.com/browse/DEVEM-342) - Update dependency `com.avast.gradle:gradle-docker-compose-plugin`
+to version 0.8.12 to solve failing `composeUp` when there is output on stderr
+
+## Version 4.0.2
+## Version 4.0.1
 ## Version 4.0.0 - 2018-10-03
 
 ### Changes

--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ dependencies {
     packaged 'org.alfresco:alfresco-mmt:5.2.g'
     compile 'com.bmuschko:gradle-docker-plugin:3.2.5'
     compile group: 'commons-io', name: 'commons-io', version: '2.5'
-    compile 'com.avast.gradle:gradle-docker-compose-plugin:0.8.8'
+    compile 'com.avast.gradle:gradle-docker-compose-plugin:0.8.12'
     compile group: 'org.apache.commons', name: 'commons-compress', version: '1.5'
     compile 'org.eclipse.jgit:org.eclipse.jgit:4.6.0.201612231935-r'
     testCompile group: 'junit', name: 'junit', version: '4.11'

--- a/src/integration-test/examples/example-docker-plugin/docker-compose.yml
+++ b/src/integration-test/examples/example-docker-plugin/docker-compose.yml
@@ -1,2 +1,6 @@
-exampledockerplugin:
- image: example-docker-plugin-local
+version: "2"
+services:
+  exampledockerplugin:
+    image: example-docker-plugin:local
+    environment:
+      - ISSUE=${GITHUB}/xenit-eu/alfresco-docker-gradle-plugin/issues/20

--- a/src/integration-test/java/eu/xenit/gradle/testrunner/ExampleRunner.java
+++ b/src/integration-test/java/eu/xenit/gradle/testrunner/ExampleRunner.java
@@ -29,6 +29,12 @@ public class ExampleRunner extends AbstractIntegrationTest {
     }
 
     @Test
+    public void testComposeUp() throws IOException {
+        testProjectFolder(EXAMPLES.resolve("example-docker-plugin"), ":composeUp");
+    }
+
+
+    @Test
     public void testFileDependencies() throws IOException {
         testProjectFolder(EXAMPLES.resolve("file-dependencies"));
     }


### PR DESCRIPTION
First commit added a test that fails with:

```
    Exit-code 1 when calling docker-compose, stdout: The GITHUB variable is not set. Defaulting to a blank string.
      No such service: The GITHUB variable is not set. Defaulting to a blank string.
```
See https://travis-ci.org/xenit-eu/alfresco-docker-gradle-plugin/jobs/458193914#L825

Updating avast dependency fixes it


