### PR TITLE
Make MergeWarTask extend the Zip task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: java
+git:
+  depth: false
+
 addons:
   apt:
     packages:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # XeniT Gradle Plugin - Changelog
 
+## Version 4.1.0 - (Unreleased)
+
+### Added
+
+ * [DEVEM-344](https://xenitsupport.jira.com/browse/DEVEM-344) - Make MergeWarTask extend the Zip task
+    - Make it easier to publish WAR files with extensions applied
+
 ## Version 4.0.3 - 2019-01-17
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -166,6 +166,26 @@ dockerAlfresco {
 }
 ```
 
+## Publishing wars with extensions
+
+Instead of creating a docker image with Alfresco and Share embedded, it is also possible to publish
+the Alfresco or Share war file with all AMPs, Dynamic Extensions and Simple Modules applied to it.
+
+The tasks `alfrescoWar` and `shareWar` create respectively an Alfresco and a Share war that can be published.
+
+```gradle
+publishing.publications {
+    alfresco(MavenPublication) {
+        artifactId "repo"
+        artifact alfrescoWar
+    }
+    share(MavenPublication) {
+        artifactId "share"
+        artifact shareWar
+    }
+}
+```
+
 ## Tagging behavior
 
 On Jenkins, the branch is set with the environment variable `BRANCH_NAME`. When it is set, all manually tags will be
@@ -176,6 +196,8 @@ When an environment variable `BUILD_NUMBER` is set, an extra tag is added: `buil
 When the branch is not master, this is also prepended.
 
 This tagging behavior can be disabled by adding `automaticTags = false` do the dockerBuild configuration.
+
+# Plugin development
 
 ## Creating a release
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,9 @@ plugins {
     id "java-gradle-plugin"
     id "maven-publish"
     id "idea"
-    id "com.gradle.plugin-publish" version "0.10.0"
-    id 'org.ajoberstar.reckon' version "0.8.0"
-    id 'com.github.johnrengelman.shadow' version '4.0.1'
+    id "com.gradle.plugin-publish" version "0.10.1"
+    id 'org.ajoberstar.reckon' version "0.9.0"
+    id 'com.github.johnrengelman.shadow' version '4.0.4'
     id "org.sonarqube" version "2.7"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "java-gradle-plugin"
     id "maven-publish"
+    id "idea"
     id "com.gradle.plugin-publish" version "0.10.0"
     id 'org.ajoberstar.reckon' version "0.8.0"
     id 'com.github.johnrengelman.shadow' version '4.0.1'
@@ -8,11 +9,6 @@ plugins {
 }
 
 group 'eu.xenit.gradle'
-
-task wrapper(type: Wrapper) {
-  gradleVersion = '4.8'
-  distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
-}
 
 sourceCompatibility = 1.8
 
@@ -32,9 +28,17 @@ sourceSets {
     }
     integrationTest {
         java {
-            compileClasspath += main.output + test.output
-            runtimeClasspath += main.output + test.output
+            compileClasspath += main.compileClasspath + test.output
+            runtimeClasspath += main.runtimeClasspath + test.output
+            srcDir file('src/integration-test/java')
         }
+    }
+}
+
+idea {
+    module {
+        testSourceDirs += sourceSets.integrationTest.java.sourceDirectories
+        testResourceDirs += sourceSets.integrationTest.resources.srcDirs
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,8 @@ sourceSets {
     }
     integrationTest {
         java {
-            compileClasspath += main.compileClasspath + test.output
-            runtimeClasspath += main.runtimeClasspath + test.output
-            srcDir file('src/integration-test/java')
+            compileClasspath += main.output
+            runtimeClasspath += main.output
         }
     }
 }

--- a/src/integrationTest/examples/example-docker-plugin/build.gradle
+++ b/src/integrationTest/examples/example-docker-plugin/build.gradle
@@ -29,6 +29,7 @@ buildDockerImage.dependsOn beforeBuild
 
 // Remove this when using the plugin
 task integrationTest {
-    dependsOn 'buildDockerImage'
-    dependsOn 'pushDockerImage'
 }
+
+dockerCompose.isRequiredBy(integrationTest)
+

--- a/src/integrationTest/examples/publish-war/build.gradle
+++ b/src/integrationTest/examples/publish-war/build.gradle
@@ -1,0 +1,35 @@
+plugins {
+    id 'eu.xenit.docker-alfresco'
+    id 'maven-publish'
+}
+
+group "eu.xenit.gradle.docker-alfresco.test.publish-war"
+version "1.0.0"
+
+repositories {
+    mavenCentral()
+    jcenter()
+    maven {
+        url "https://artifacts.alfresco.com/nexus/content/groups/public/"
+    }
+}
+
+dependencies {
+    baseAlfrescoWar "org.alfresco:content-services-community:6.0.a@war"
+    alfrescoAmp "de.fmaul:javascript-console-repo:0.6@amp"
+    baseShareWar "org.alfresco:share:6.0.c@war"
+    shareAmp "de.fmaul:javascript-console-share:0.6@amp"
+}
+
+publishing.publications {
+    alfresco(MavenPublication) {
+        artifactId "repository"
+        artifact mergeAlfrescoWar
+    }
+
+    share(MavenPublication) {
+        artifactId "share"
+        artifact mergeShareWar
+    }
+}
+

--- a/src/integrationTest/examples/publish-war/build.gradle
+++ b/src/integrationTest/examples/publish-war/build.gradle
@@ -24,12 +24,12 @@ dependencies {
 publishing.publications {
     alfresco(MavenPublication) {
         artifactId "repository"
-        artifact mergeAlfrescoWar
+        artifact alfrescoWar
     }
 
     share(MavenPublication) {
         artifactId "share"
-        artifact mergeShareWar
+        artifact shareWar
     }
 }
 

--- a/src/integrationTest/java/eu/xenit/gradle/testrunner/ExampleRunner.java
+++ b/src/integrationTest/java/eu/xenit/gradle/testrunner/ExampleRunner.java
@@ -69,4 +69,9 @@ public class ExampleRunner extends AbstractIntegrationTest {
         testProjectFolder(EXAMPLES.resolve("lean-example"));
     }
 
+    @Test
+    public void publishWar() throws IOException {
+        testProjectFolder(EXAMPLES.resolve("publish-war"), ":publishToMavenLocal");
+    }
+
 }

--- a/src/integrationTest/java/eu/xenit/gradle/testrunner/ExampleRunner.java
+++ b/src/integrationTest/java/eu/xenit/gradle/testrunner/ExampleRunner.java
@@ -30,7 +30,7 @@ public class ExampleRunner extends AbstractIntegrationTest {
 
     @Test
     public void testComposeUp() throws IOException {
-        testProjectFolder(EXAMPLES.resolve("example-docker-plugin"), ":composeUp");
+        testProjectFolder(EXAMPLES.resolve("example-docker-plugin"), ":integrationTest");
     }
 
 

--- a/src/main/java/eu/xenit/gradle/alfresco/DockerAlfrescoPlugin.java
+++ b/src/main/java/eu/xenit/gradle/alfresco/DockerAlfrescoPlugin.java
@@ -1,5 +1,6 @@
 package eu.xenit.gradle.alfresco;
 
+import eu.xenit.gradle.alfresco.tasks.internal.DeprecatedMergeWarTask;
 import eu.xenit.gradle.docker.DockerBuildBehavior;
 import eu.xenit.gradle.docker.DockerConfigPlugin;
 import eu.xenit.gradle.tasks.DockerfileWithWarsTask;
@@ -133,8 +134,12 @@ public class DockerAlfrescoPlugin implements Plugin<Project> {
         List<WarLabelOutputTask> outputTasks = new ArrayList<>(tasks);
         outputTasks.add(0, resolveTask);
 
-        MergeWarsTask mergeWarsTask = project.getTasks().create("merge"+warName+"War", MergeWarsTask.class);
+        MergeWarsTask mergeWarsTask = project.getTasks().create(warName.toLowerCase()+"War", MergeWarsTask.class);
         mergeWarsTask.setGroup(TASK_GROUP);
+
+        DeprecatedMergeWarTask oldMergeWarsTask = project.getTasks().create("merge"+warName+"War", DeprecatedMergeWarTask.class);
+        oldMergeWarsTask.setGroup(TASK_GROUP);
+        oldMergeWarsTask.setReplacementTask(mergeWarsTask);
 
         for(WarLabelOutputTask task: outputTasks) {
             mergeWarsTask.withLabels(task);

--- a/src/main/java/eu/xenit/gradle/alfresco/tasks/internal/DeprecatedMergeWarTask.java
+++ b/src/main/java/eu/xenit/gradle/alfresco/tasks/internal/DeprecatedMergeWarTask.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.Task;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;

--- a/src/main/java/eu/xenit/gradle/alfresco/tasks/internal/DeprecatedMergeWarTask.java
+++ b/src/main/java/eu/xenit/gradle/alfresco/tasks/internal/DeprecatedMergeWarTask.java
@@ -1,0 +1,54 @@
+package eu.xenit.gradle.alfresco.tasks.internal;
+
+import eu.xenit.gradle.tasks.LabelConsumerTask;
+import eu.xenit.gradle.tasks.MergeWarsTask;
+import eu.xenit.gradle.tasks.WarLabelOutputTask;
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.Task;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+
+public class DeprecatedMergeWarTask extends DefaultTask implements LabelConsumerTask, WarLabelOutputTask {
+
+    private MergeWarsTask replacementTask;
+
+    public void setReplacementTask(MergeWarsTask replacementTask) {
+        this.replacementTask = replacementTask;
+        dependsOn(replacementTask);
+    }
+
+    @TaskAction
+    public void runTask() {
+        getLogger()
+                .warn("[eu.xenit.docker-alfresco] The task " + getName()
+                        + " is deprecated and will be removed in alfresco-docker-gradle-plugin 5.0.0. Use "
+                        + replacementTask.getName() + " instead.");
+    }
+
+    @Override
+    public void withLabels(Supplier<Map<String, String>> labels) {
+        replacementTask.withLabels(labels);
+
+    }
+
+    @Override
+    @Input
+    public Map<String, String> getLabels() {
+        return replacementTask.getLabels();
+    }
+
+    public void setInputWars(Supplier<List<File>> inputWars) {
+        replacementTask.setInputWars(inputWars);
+    }
+
+    @Override
+    @OutputFile
+    public File getOutputWar() {
+        return replacementTask.getOutputWar();
+    }
+}

--- a/src/main/java/eu/xenit/gradle/tasks/InjectFilesInWarTask.java
+++ b/src/main/java/eu/xenit/gradle/tasks/InjectFilesInWarTask.java
@@ -57,11 +57,6 @@ public class InjectFilesInWarTask extends DefaultTask implements WarEnrichmentTa
         return outputWar.get();
     }
 
-    @Override
-    public void setOutputWar(Supplier<File> outputWar) {
-        this.outputWar = outputWar;
-    }
-
     @InputFiles
     public Set<File> getSourceFiles()
     {

--- a/src/main/java/eu/xenit/gradle/tasks/MergeWarsTask.java
+++ b/src/main/java/eu/xenit/gradle/tasks/MergeWarsTask.java
@@ -16,11 +16,6 @@ import org.gradle.api.tasks.bundling.Zip;
 
 public class MergeWarsTask extends Zip implements LabelConsumerTask, WarLabelOutputTask {
 
-    /**
-     * WAR file used as output (is created from inputWar)
-     */
-    private Supplier<File> outputWar = () -> { return getProject().getBuildDir().toPath().resolve("xenit-gradle-plugins").resolve(getName()).resolve(getName()+".war").toFile(); };
-
     private List<Supplier<Map<String, String>>> labels = new ArrayList<>();
 
     private final CopySpec childWars;

--- a/src/main/java/eu/xenit/gradle/tasks/MergeWarsTask.java
+++ b/src/main/java/eu/xenit/gradle/tasks/MergeWarsTask.java
@@ -1,22 +1,20 @@
 package eu.xenit.gradle.tasks;
 
-import de.schlichtherle.truezip.file.TFile;
-import org.gradle.api.DefaultTask;
-import org.gradle.api.tasks.*;
-
 import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import org.gradle.api.file.CopySpec;
+import org.gradle.api.file.FileTree;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.bundling.Zip;
 
-public class MergeWarsTask extends DefaultTask implements LabelConsumerTask, WarLabelOutputTask {
-    /**
-     * WAR files used as input (are not modified)
-     *
-     * Later files overwrite earlier files
-     */
-    private Supplier<List<File>> inputWars;
+public class MergeWarsTask extends Zip implements LabelConsumerTask, WarLabelOutputTask {
 
     /**
      * WAR file used as output (is created from inputWar)
@@ -24,6 +22,17 @@ public class MergeWarsTask extends DefaultTask implements LabelConsumerTask, War
     private Supplier<File> outputWar = () -> { return getProject().getBuildDir().toPath().resolve("xenit-gradle-plugins").resolve(getName()).resolve(getName()+".war").toFile(); };
 
     private List<Supplier<Map<String, String>>> labels = new ArrayList<>();
+
+    private final CopySpec childWars;
+
+    public MergeWarsTask() {
+        super();
+        setExtension("war");
+        setDestinationDir(
+                getProject().getBuildDir().toPath().resolve("xenit-gradle-plugins").resolve(getName()).toFile());
+        setBaseName(getName());
+        childWars = getRootSpec().addChildBeforeSpec(getMainSpec());
+    }
 
     @Override
     public void withLabels(Supplier<Map<String, String>> labels) {
@@ -40,39 +49,22 @@ public class MergeWarsTask extends DefaultTask implements LabelConsumerTask, War
         return accumulator;
     }
 
-    @InputFiles
-    public List<File> getInputWars() {
-        return inputWars.get();
-    }
-
+    /**
+     * WAR files used as input (are not modified)
+     * <p>
+     * Later files overwrite earlier files
+     */
     public void setInputWars(Supplier<List<File>> inputWars) {
-        this.inputWars = inputWars;
+        childWars.from((Callable<List<FileTree>>) () -> inputWars.get()
+                .stream()
+                .map(war -> getProject().zipTree(war))
+                .collect(Collectors.toList()));
     }
 
     @Override
     @OutputFile
     public File getOutputWar() {
-        return outputWar.get();
-    }
-
-    @Override
-    public void setOutputWar(Supplier<File> outputWar) {
-        this.outputWar = outputWar;
-    }
-
-    @TaskAction
-    public void stripWar() {
-        for(File file: getInputWars()) {
-            Util.withWar(file, inputWar -> {
-                Util.withWar(getOutputWar(), outputWar -> {
-                    try {
-                        TFile.cp_rp(inputWar, outputWar, inputWar.getArchiveDetector(), outputWar.getArchiveDetector());
-                    } catch (IOException e) {
-                        throw new UncheckedIOException(e);
-                    }
-                });
-            });
-        }
+        return getDestinationDir().toPath().resolve(getName()).toFile();
     }
 
 }

--- a/src/main/java/eu/xenit/gradle/tasks/ResolveWarTask.java
+++ b/src/main/java/eu/xenit/gradle/tasks/ResolveWarTask.java
@@ -47,11 +47,6 @@ public class ResolveWarTask extends DefaultTask implements WarEnrichmentTask {
     }
 
     @Override
-    public void setOutputWar(Supplier<File> outputWar) {
-        throw new UnsupportedOperationException("outputWar is required to be the same as inputWar");
-    }
-
-    @Override
     public void withLabels(Supplier<Map<String, String>> labels) {
         this.labels.add(labels);
     }

--- a/src/main/java/eu/xenit/gradle/tasks/WarOutputTask.java
+++ b/src/main/java/eu/xenit/gradle/tasks/WarOutputTask.java
@@ -1,24 +1,11 @@
 package eu.xenit.gradle.tasks;
 
-import groovy.lang.Closure;
 import org.gradle.api.Task;
 import org.gradle.api.tasks.OutputFile;
 
 import java.io.File;
-import java.util.function.Supplier;
 
 public interface WarOutputTask extends Task {
     @OutputFile
     File getOutputWar();
-
-    void setOutputWar(Supplier<File> outputWar);
-
-    default void setOutputWar(Closure<File> outputWar) {
-        setOutputWar(() -> outputWar.call());
-    }
-
-    default void setOutputWar(File outputWar) {
-        setOutputWar(() -> outputWar);
-    }
-
 }


### PR DESCRIPTION
Creating a new one for #17 because the source branch is gone

To make it easier to publish alfresco/share war as artifact, I made it extend the `Zip` task.

However, this change makes it difficult to keep supporting the `setOutputWar()` method to choose where you want to place the output war.
It also changes the location in the build directory where the output war is located by default.

Given that the `MergeWarTask` was not part of the documented public API, we should be able to change it in a minor release.

This change will deprecate `mergeAlfrescoWar` and `mergeShareWar`, replacing them with `alfrescoWar` and `shareWar` tasks, to be more consistent with the naming of other Gradle tasks.

This change will also make the `alfrescoWar` and `shareWar` tasks part of the public API, and they are documented as a way to publish the generated wars.

Publishing can be achieved with:
```gradle
publishing {
    publications {
        alfrescoWar(MavenPublication) {
            artifactId "alfresco"
            artifact alfrescoWar
        }

        shareWar(MavenPublication) {
            artifactId "share"
            artifact shareWar
        }
    }
}
```

It is required to create two different publications and set the `artifactId` for each one since the alfresco and share war have the same type and classifier and would overwrite each other if they did not have a different artifact id.

They would be referred to from other projects like `groupname:alfresco:version@war` and `groupname:share:version@war`

An other possibility is to set the classifier on one or both of the `MergeWarTask`s

```gradle
alfrescoWar {
   classifier "alfresco"
}
shareWar {
    classifier "share"
}
publishing {
    publications {
        wars(MavenPublication) {
            artifact alfrescoWar
            artifact shareWar
        }
    }
}
```

This will make both artifacts share the same pom and forces them to have the same version.
They would be referred to from other projects like `groupname:projectname:version:alfresco@war` and `groupname:projectname:version:share@war`

Fixes #13 