### PR TITLE
Only unmount the particular truezip file that is being worked on, instead of unmounting all items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
     - Make it easier to publish WAR files with extensions applied
  * [#44](https://github.com/xenit-eu/alfresco-docker-gradle-plugin/issues/44) - Automatically apply amps in the correct order
 
+### Fixes
+
+ * [#38](https://github.com/xenit-eu/alfresco-docker-gradle-plugin/issues/38) - DockerfileWithWarsTask is not threadsafe
+
 ## Version 4.0.3 - 2019-01-17
 
 ### Fixes

--- a/src/main/java/eu/xenit/gradle/tasks/StripAlfrescoWarTask.java
+++ b/src/main/java/eu/xenit/gradle/tasks/StripAlfrescoWarTask.java
@@ -1,20 +1,14 @@
 package eu.xenit.gradle.tasks;
 
 import de.schlichtherle.truezip.file.TFile;
-import org.alfresco.repo.module.tool.WarHelperImpl;
-import org.gradle.api.DefaultTask;
-import org.gradle.api.tasks.InputFile;
-import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.OutputFile;
-import org.gradle.api.tasks.TaskAction;
-
-import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.*;
-import java.util.function.Supplier;
+import java.util.HashSet;
+import java.util.Set;
+import org.gradle.api.tasks.TaskAction;
 
 public class StripAlfrescoWarTask extends ResolveWarTask {
+
     private Set<String> pathsToCopy = new HashSet<>();
 
     public void addPathToCopy(String path) {
@@ -27,9 +21,9 @@ public class StripAlfrescoWarTask extends ResolveWarTask {
         Util.withWar(getInputWar(), inputWar -> {
             Util.withWar(getOutputWar(), outputWar -> {
                 try {
-                    for(String pathToCopy: pathsToCopy)  {
-                        TFile fileToCopy = new TFile(inputWar.getAbsolutePath()+pathToCopy);
-                        TFile fileToReceive = new TFile(outputWar.getAbsolutePath()+pathToCopy);
+                    for (String pathToCopy : pathsToCopy) {
+                        TFile fileToCopy = new TFile(inputWar.getAbsolutePath() + pathToCopy);
+                        TFile fileToReceive = new TFile(outputWar.getAbsolutePath() + pathToCopy);
                         TFile.cp(fileToCopy, fileToReceive);
                     }
                 } catch (IOException e) {

--- a/src/main/java/eu/xenit/gradle/tasks/Util.java
+++ b/src/main/java/eu/xenit/gradle/tasks/Util.java
@@ -7,23 +7,24 @@ import de.schlichtherle.truezip.file.TVFS;
 import de.schlichtherle.truezip.fs.FsSyncException;
 import de.schlichtherle.truezip.fs.archive.zip.JarDriver;
 import de.schlichtherle.truezip.socket.sl.IOPoolLocator;
-
 import java.io.File;
 import java.util.function.Consumer;
 
 class Util {
 
     static void withWar(File warFile, Consumer<TFile> closure) {
+        TConfig config = TConfig.get();
+        config.setArchiveDetector(new TArchiveDetector("war|amp", new JarDriver(IOPoolLocator.SINGLETON)));
+        TFile archive = new TFile(warFile);
         try {
-            TConfig config = TConfig.get();
-            config.setArchiveDetector(new TArchiveDetector("war|amp", new JarDriver(IOPoolLocator.SINGLETON)));
-            TFile archive = new TFile(warFile);
             closure.accept(archive);
         } finally {
             try {
-                TVFS.umount();
-            } catch (FsSyncException e) {
-                throw new IllegalStateException(e);
+                TVFS.umount(archive);
+            } catch (FsSyncException ignored) {
+                // This exception is intentionally ignored.
+                // Throwing exceptions in a finally block would swallow the original exception
+                // And it is no big deal if the archive can not be unmounted now, it will be unmounted during process shutdown anyways
             }
         }
     }


### PR DESCRIPTION
When we only unmount a particular file that is being worked on, there is no risk of stomping upon other threads working with other `TFile`s in parallel.

Fixes #38 