### PR TITLE
Lazy resolve baseXWar dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
  * [#38](https://github.com/xenit-eu/alfresco-docker-gradle-plugin/issues/38) - DockerfileWithWarsTask is not threadsafe
  * [#33](https://github.com/xenit-eu/alfresco-docker-gradle-plugin/issues/33) - Warning messages when building with Java 11
  * [#45](https://github.com/xenit-eu/alfresco-docker-gradle-plugin/issues/45) - Handle initialized git repository without commits
+ * [#36](https://github.com/xenit-eu/alfresco-docker-gradle-plugin/issues/36) - Dependencies are resolved during the configuration phase
 
 ## Version 4.0.3 - 2019-01-17
 

--- a/src/main/java/eu/xenit/gradle/alfresco/DockerAlfrescoPlugin.java
+++ b/src/main/java/eu/xenit/gradle/alfresco/DockerAlfrescoPlugin.java
@@ -71,30 +71,27 @@ public class DockerAlfrescoPlugin implements Plugin<Project> {
         return dockerfile;
     }
 
-    private void updateDockerFileTask(Project project1, DockerfileWithWarsTask dockerfile, List<WarLabelOutputTask> alfrescoTasks, List<WarLabelOutputTask> shareTasks, DockerAlfrescoExtension dockerAlfrescoExtension) {
-        if(dockerAlfrescoExtension.getLeanImage()){
+    private void updateDockerFileTask(Project project1, DockerfileWithWarsTask dockerfile,
+            List<WarLabelOutputTask> alfrescoTasks, List<WarLabelOutputTask> shareTasks,
+            DockerAlfrescoExtension dockerAlfrescoExtension) {
+        if (dockerAlfrescoExtension.getLeanImage()) {
             dockerfile.setRemoveExistingWar(false);
         }
         Configuration alfrescoBaseWar = project1.getConfigurations().getByName(BASE_ALFRESCO_WAR);
-        if(!alfrescoBaseWar.isEmpty()) {
-            //don't add base Alfresco war when making lean image
-            if(!dockerAlfrescoExtension.getLeanImage()) {
-                dockerfile.addWar("alfresco", alfrescoBaseWar);
-            }
-            for (WarLabelOutputTask task : alfrescoTasks) {
-                dockerfile.addWar("alfresco", task);
-            }
+        if (!dockerAlfrescoExtension.getLeanImage()) {
+            dockerfile.addWar("alfresco", () -> alfrescoBaseWar.isEmpty() ? null : alfrescoBaseWar.getSingleFile());
         }
+        alfrescoTasks.forEach(t -> {
+            dockerfile.addWar("alfresco", t);
+        });
+
         Configuration shareBaseWar = project1.getConfigurations().getByName(BASE_SHARE_WAR);
-        if(!shareBaseWar.isEmpty()) {
-            //don't add base Share war when making lean image
-            if(!dockerAlfrescoExtension.getLeanImage()){
-                dockerfile.addWar("share", shareBaseWar);
-            }
-            for (WarLabelOutputTask task : shareTasks) {
-                dockerfile.addWar("share", task);
-            }
+        if (!dockerAlfrescoExtension.getLeanImage()) {
+            dockerfile.addWar("share", () -> shareBaseWar.isEmpty() ? null : shareBaseWar.getSingleFile());
         }
+        shareTasks.forEach(t -> {
+            dockerfile.addWar("share", t);
+        });
     }
 
     private List<WarLabelOutputTask> warEnrichmentChain(Project project, final String warName) {

--- a/src/main/java/eu/xenit/gradle/tasks/InjectFilesInWarTask.java
+++ b/src/main/java/eu/xenit/gradle/tasks/InjectFilesInWarTask.java
@@ -45,19 +45,19 @@ public class InjectFilesInWarTask extends DefaultTask implements WarEnrichmentTa
 
     @InputFiles
     @SkipWhenEmpty
-    public FileCollection getInputFiles_() {
+    public FileCollection get_internal_inputFiles() {
         return inputWar;
     }
 
     @Override
-    public void setInputFiles_(FileCollection fileCollection) {
+    public void set_internal_inputFiles(FileCollection fileCollection) {
         inputWar = fileCollection;
     }
 
     @OutputFile
     @Override
     public File getOutputWar() {
-        if(inputWar.isEmpty()) {
+        if (inputWar.isEmpty()) {
             return null;
         }
         return getProject().getBuildDir().toPath().resolve("xenit-gradle-plugins").resolve(getName())
@@ -70,25 +70,21 @@ public class InjectFilesInWarTask extends DefaultTask implements WarEnrichmentTa
         return sourceFiles.get();
     }
 
-    public void setSourceFiles(FileCollection fileCollection)
-    {
+    public void setSourceFiles(FileCollection fileCollection) {
         dependsOn(fileCollection);
         setSourceFiles(fileCollection::getFiles);
     }
 
-    public void setSourceFiles(Task task)
-    {
+    public void setSourceFiles(Task task) {
         dependsOn(task);
         setSourceFiles(() -> task.getOutputs().getFiles().getFiles());
     }
 
-    public void setSourceFiles(Supplier<Set<File>> files)
-    {
+    public void setSourceFiles(Supplier<Set<File>> files) {
         sourceFiles = files;
     }
 
-    public void setSourceFiles(Set<File> files)
-    {
+    public void setSourceFiles(Set<File> files) {
         setSourceFiles(() -> files);
     }
 

--- a/src/main/java/eu/xenit/gradle/tasks/ResolveWarTask.java
+++ b/src/main/java/eu/xenit/gradle/tasks/ResolveWarTask.java
@@ -31,17 +31,14 @@ public class ResolveWarTask extends DefaultTask implements WarEnrichmentTask {
     private FileCollection war;
     private List<Supplier<Map<String, String>>> labels = new ArrayList<>();
 
-    /**
-     * Internal function so the task can be skipped with no-source when no war is given
-     */
     @InputFiles
     @SkipWhenEmpty
-    public FileCollection getInputFiles_() {
+    public FileCollection get_internal_inputFiles() {
         return war;
     }
 
     @Override
-    public void setInputFiles_(FileCollection fileCollection) {
+    public void set_internal_inputFiles(FileCollection fileCollection) {
         war = fileCollection;
     }
 

--- a/src/main/java/eu/xenit/gradle/tasks/Util.java
+++ b/src/main/java/eu/xenit/gradle/tasks/Util.java
@@ -8,14 +8,17 @@ import de.schlichtherle.truezip.fs.FsSyncException;
 import de.schlichtherle.truezip.fs.archive.zip.JarDriver;
 import de.schlichtherle.truezip.socket.sl.IOPoolLocator;
 import java.io.File;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 class Util {
 
     static void withWar(File warFile, Consumer<TFile> closure) {
-        TConfig config = TConfig.get();
-        config.setArchiveDetector(new TArchiveDetector("war|amp", new JarDriver(IOPoolLocator.SINGLETON)));
-        TFile archive = new TFile(warFile);
+        Objects.requireNonNull(warFile, "warFile");
+        Objects.requireNonNull(closure, "closure");
+            TConfig config = TConfig.get();
+            config.setArchiveDetector(new TArchiveDetector("war|amp", new JarDriver(IOPoolLocator.SINGLETON)));
+            TFile archive = new TFile(warFile);
         try {
             closure.accept(archive);
         } finally {

--- a/src/main/java/eu/xenit/gradle/tasks/WarInputTask.java
+++ b/src/main/java/eu/xenit/gradle/tasks/WarInputTask.java
@@ -1,30 +1,38 @@
 package eu.xenit.gradle.tasks;
 
 import groovy.lang.Closure;
-import org.gradle.api.Task;
-import org.gradle.api.file.FileCollection;
-import org.gradle.api.tasks.InputFile;
-
 import java.io.File;
 import java.util.function.Supplier;
+import org.gradle.api.Task;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.SkipWhenEmpty;
 
 public interface WarInputTask extends Task {
-    @InputFile
-    File getInputWar();
 
-    default void setInputWar(FileCollection configuration)
-    {
-        dependsOn(configuration);
-        setInputWar(configuration::getSingleFile);
+    @InputFiles
+    @SkipWhenEmpty
+    FileCollection getInputFiles_();
+
+    void setInputFiles_(FileCollection fileCollection);
+
+    @Internal
+    default File getInputWar() {
+        return getInputFiles_().getSingleFile();
     }
 
-    default void setInputWar(WarOutputTask task)
-    {
-        dependsOn(task);
-        setInputWar(task::getOutputWar);
+    default void setInputWar(FileCollection configuration) {
+        setInputFiles_(configuration);
     }
 
-    void setInputWar(Supplier<File> inputWar);
+    default void setInputWar(WarOutputTask task) {
+        setInputFiles_(getProject().files(task));
+    }
+
+    default void setInputWar(Supplier<File> inputWar) {
+        setInputFiles_(getProject().files(inputWar));
+    }
 
     default void setInputWar(File inputWar) {
         setInputWar(() -> inputWar);

--- a/src/main/java/eu/xenit/gradle/tasks/WarInputTask.java
+++ b/src/main/java/eu/xenit/gradle/tasks/WarInputTask.java
@@ -11,27 +11,33 @@ import org.gradle.api.tasks.SkipWhenEmpty;
 
 public interface WarInputTask extends Task {
 
+    /**
+     * Internal function so the task can be skipped with no-source when no war is given
+     */
     @InputFiles
     @SkipWhenEmpty
-    FileCollection getInputFiles_();
+    FileCollection get_internal_inputFiles();
 
-    void setInputFiles_(FileCollection fileCollection);
+    /**
+     * Internal function so the file collection can be set from default methods
+     */
+    void set_internal_inputFiles(FileCollection fileCollection);
 
     @Internal
     default File getInputWar() {
-        return getInputFiles_().getSingleFile();
+        return get_internal_inputFiles().getSingleFile();
     }
 
     default void setInputWar(FileCollection configuration) {
-        setInputFiles_(configuration);
+        set_internal_inputFiles(configuration);
     }
 
     default void setInputWar(WarOutputTask task) {
-        setInputFiles_(getProject().files(task));
+        set_internal_inputFiles(getProject().files(task));
     }
 
     default void setInputWar(Supplier<File> inputWar) {
-        setInputFiles_(getProject().files(inputWar));
+        set_internal_inputFiles(getProject().files(inputWar));
     }
 
     default void setInputWar(File inputWar) {

--- a/src/test/java/eu/xenit/gradle/alfresco/DockerAlfrescoPluginTest.java
+++ b/src/test/java/eu/xenit/gradle/alfresco/DockerAlfrescoPluginTest.java
@@ -1,5 +1,6 @@
 package eu.xenit.gradle.alfresco;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 import eu.xenit.gradle.JenkinsUtil;
@@ -10,6 +11,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Arrays;
 import org.gradle.api.UnknownTaskException;
+import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal.InternalState;
+import org.gradle.api.internal.artifacts.configurations.DefaultConfiguration;
 import org.gradle.api.internal.project.DefaultProject;
 import org.gradle.internal.impldep.org.junit.Assert;
 import org.gradle.testfixtures.ProjectBuilder;
@@ -131,6 +134,24 @@ public class DockerAlfrescoPluginTest {
         project.evaluate();
         checkTaskExists(project, "applyAlfrescoSM");
         checkTaskExists(project, "applyShareSM");
+    }
+
+    @Test
+    public void testLazyResolve() {
+        DefaultProject project = getDefaultProject();
+        project.getDependencies().add("baseAlfrescoWar",
+                project.files(this.getClass().getClassLoader().getResource("test123.war").getFile()));
+        project.getDependencies().add("baseShareWar",
+                project.files(this.getClass().getClassLoader().getResource("test123.war").getFile()));
+
+        project.evaluate();
+
+        DefaultConfiguration alfrescoConfiguration = (DefaultConfiguration) project.getConfigurations()
+                .getByName("baseAlfrescoWar");
+        assertEquals(InternalState.UNRESOLVED, alfrescoConfiguration.getResolvedState());
+        DefaultConfiguration shareConfiguration = (DefaultConfiguration) project.getConfigurations()
+                .getByName("baseShareWar");
+        assertEquals(InternalState.UNRESOLVED, shareConfiguration.getResolvedState());
     }
 
 //    @Test


### PR DESCRIPTION
Dependencies were resolved during the configuration of the project, which resulted in the alfresco and share wars being always being downloaded, even if they are not used in the current run.

This hurts especially when running projects like docker-alfresco or docker-share, because all the wars are downloaded even if you only want to build one specific version.

This pullrequests makes all tasks operating on the wars to be `@SkipWhenEmpty`, so they are skipped with NO-SOURCE if no war is given to them.

Fixes #36