### PR TITLE
Improve DX to add additional files to an alfresco docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  * [DEVEM-344](https://xenitsupport.jira.com/browse/DEVEM-344) - Make MergeWarTask extend the Zip task
     - Make it easier to publish WAR files with extensions applied
  * [#44](https://github.com/xenit-eu/alfresco-docker-gradle-plugin/issues/44) - Automatically apply amps in the correct order
+ * [#42](https://github.com/xenit-eu/alfresco-docker-gradle-plugin/issues/42) - Improve experience to add additional files to a docker image
  
 ### Fixes
 

--- a/src/integrationTest/examples/add-files-dockerfile/build.gradle
+++ b/src/integrationTest/examples/add-files-dockerfile/build.gradle
@@ -42,7 +42,6 @@ task startContainer(type: DockerStartContainer) {
 
 task waitContainer(type: DockerWaitContainer) {
     targetContainerId { createContainer.containerId }
-    timeout = 10
     dependsOn(startContainer)
 
     doLast {

--- a/src/integrationTest/examples/add-files-dockerfile/build.gradle
+++ b/src/integrationTest/examples/add-files-dockerfile/build.gradle
@@ -30,18 +30,18 @@ createDockerFile {
 import com.bmuschko.gradle.docker.tasks.container.*
 
 task createContainer(type: DockerCreateContainer) {
-    targetImageId { buildDockerImage.imageId }
+    targetImageId buildDockerImage.imageId
     cmd = ["/test.sh"]
     dependsOn(buildDockerImage)
 }
 
 task startContainer(type: DockerStartContainer) {
-    targetContainerId { createContainer.containerId }
+    targetContainerId createContainer.containerId
     dependsOn(createContainer)
 }
 
 task waitContainer(type: DockerWaitContainer) {
-    targetContainerId { createContainer.containerId }
+    targetContainerId createContainer.containerId
     dependsOn(startContainer)
 
     doLast {

--- a/src/integrationTest/examples/add-files-dockerfile/build.gradle
+++ b/src/integrationTest/examples/add-files-dockerfile/build.gradle
@@ -20,10 +20,10 @@ dockerAlfresco {
 }
 
 createDockerFile {
-    copyFile file("build.gradle"), "/opt/build.gradle"
+    smartCopy "build.gradle", "/opt/build.gradle"
     runCommand "mkdir -p /opt/gradle/test-src"
-    copyFile files("directory"), "/opt/gradle/test-src"
-    copyFile file("test.sh"), "/"
+    smartCopy files("directory"), "/opt/gradle/test-src"
+    smartCopy file("test.sh"), "/"
     runCommand "chmod +x /test.sh"
 }
 

--- a/src/integrationTest/examples/add-files-dockerfile/build.gradle
+++ b/src/integrationTest/examples/add-files-dockerfile/build.gradle
@@ -1,0 +1,53 @@
+plugins {
+    id 'eu.xenit.docker-alfresco'
+}
+
+repositories {
+    mavenCentral()
+    jcenter()
+    maven {
+        url "https://artifacts.alfresco.com/nexus/content/groups/public/"
+    }
+}
+dependencies {
+    baseAlfrescoWar "org.alfresco:content-services-community:6.0.a@war"
+}
+dockerAlfresco {
+    baseImage = "tomcat:7-jre8"
+    dockerBuild {
+        repository = 'hellotest'
+    }
+}
+
+createDockerFile {
+    copyFile file("build.gradle"), "/opt/build.gradle"
+    runCommand "mkdir -p /opt/gradle/test-src"
+    copyFile files("directory"), "/opt/gradle/test-src"
+    copyFile file("test.sh"), "/"
+    runCommand "chmod +x /test.sh"
+}
+
+import com.bmuschko.gradle.docker.tasks.container.*
+
+task createContainer(type: DockerCreateContainer) {
+    targetImageId { buildDockerImage.imageId }
+    cmd = ["/test.sh"]
+    dependsOn(buildDockerImage)
+}
+
+task startContainer(type: DockerStartContainer) {
+    targetContainerId { createContainer.containerId }
+    dependsOn(createContainer)
+}
+
+task waitContainer(type: DockerWaitContainer) {
+    targetContainerId { createContainer.containerId }
+    timeout = 10
+    dependsOn(startContainer)
+
+    doLast {
+        if (exitCode != 0) {
+            throw new GradleException("Container did not exit with code 0");
+        }
+    }
+}

--- a/src/integrationTest/examples/add-files-dockerfile/test.sh
+++ b/src/integrationTest/examples/add-files-dockerfile/test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+stat /opt/build.gradle || exit 1
+stat /opt/gradle/test-src/blah/x || exit 1
+exit 0

--- a/src/integrationTest/java/eu/xenit/gradle/testrunner/AbstractIntegrationTest.java
+++ b/src/integrationTest/java/eu/xenit/gradle/testrunner/AbstractIntegrationTest.java
@@ -89,7 +89,7 @@ public abstract class AbstractIntegrationTest {
 
         return GradleRunner.create()
                 .withProjectDir(tempExample)
-                .withArguments(task, "--stacktrace", "--rerun-tasks")
+                .withArguments(task, "--stacktrace", "--rerun-tasks", "--info")
                 .withGradleVersion(gradleVersion)
                 .withPluginClasspath()
                 .withDebug(true)

--- a/src/integrationTest/java/eu/xenit/gradle/testrunner/ExampleRunner.java
+++ b/src/integrationTest/java/eu/xenit/gradle/testrunner/ExampleRunner.java
@@ -14,6 +14,11 @@ public class ExampleRunner extends AbstractIntegrationTest {
     private static Path EXAMPLES = Paths.get("src", "integrationTest", "examples");
 
     @Test
+    public void testAddFilesDockerfile() throws IOException {
+        testProjectFolder(EXAMPLES.resolve("add-files-dockerfile"), ":waitContainer");
+    }
+
+    @Test
     public void testAlfrescoWarOnly() throws IOException {
         testProjectFolder(EXAMPLES.resolve("alfresco-war-only"));
     }

--- a/src/main/java/eu/xenit/gradle/tasks/DockerfileWithCopyTask.java
+++ b/src/main/java/eu/xenit/gradle/tasks/DockerfileWithCopyTask.java
@@ -1,0 +1,125 @@
+package eu.xenit.gradle.tasks;
+
+import com.bmuschko.gradle.docker.tasks.image.Dockerfile;
+import java.io.File;
+import java.util.LinkedList;
+import java.util.List;
+import org.gradle.api.file.CopySpec;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.tasks.TaskAction;
+
+public class DockerfileWithCopyTask extends Dockerfile {
+
+    private abstract class DockerCopyAction {
+
+        abstract public CopySpec getCopySpec();
+
+        public CopyFileInstruction getCopyInstruction() {
+            return new CopyFileInstruction(getTemporaryDirectory(), destinationInImage);
+        }
+
+        abstract public boolean isEmpty();
+
+        protected final String destinationInImage;
+        protected final int copyActionIndex;
+
+        DockerCopyAction(String destinationInImage) {
+            this.destinationInImage = destinationInImage;
+            copyActionIndex = ++copyActionCounter;
+            getInputs().property("dockerCopyAction." + copyActionIndex + ".dest", destinationInImage);
+        }
+
+        public String getTemporaryDirectory() {
+            return "copyAction" + copyActionIndex;
+        }
+    }
+
+    private class DockerCopyCollectionAction extends DockerCopyAction {
+
+        private final FileCollection files;
+
+        private DockerCopyCollectionAction(FileCollection files, String destinationInImage) {
+            super(destinationInImage);
+            this.files = files;
+            getInputs().files(files)
+                    .withPropertyName("dockerCopyAction." + copyActionIndex + ".files");
+        }
+
+        @Override
+        public CopySpec getCopySpec() {
+            return getProject().copySpec(copySpec -> {
+                copySpec.from(files);
+                copySpec.into(getTemporaryDirectory());
+            });
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return files.isEmpty();
+        }
+
+    }
+
+    private class DockerCopyFileAction extends DockerCopyAction {
+
+        private final File file;
+
+        private DockerCopyFileAction(File file, String destinationInImage) {
+            super(destinationInImage);
+            this.file = file;
+            getInputs().file(file)
+                    .withPropertyName("dockerCopyAction." + copyActionIndex + ".file");
+        }
+
+
+        @Override
+        public CopySpec getCopySpec() {
+            return getProject().copySpec(copySpec -> {
+                copySpec.from(file);
+                copySpec.into(getTemporaryDirectory());
+            });
+        }
+
+        @Override
+        public CopyFileInstruction getCopyInstruction() {
+            return new CopyFileInstruction(getTemporaryDirectory() + "/" + file.getName(),
+                    destinationInImage);
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return false;
+        }
+    }
+
+    private int copyActionCounter = 0;
+
+    private final List<DockerCopyAction> copyActions = new LinkedList<>();
+
+    public void copyFile(File file, String destinationInImage) {
+        copyActions.add(new DockerCopyFileAction(file, destinationInImage));
+    }
+
+    public void copyFile(FileCollection files, String destinationInImage) {
+        copyActions.add(new DockerCopyCollectionAction(files, destinationInImage));
+    }
+
+    @TaskAction
+    @Override
+    public void create() {
+        for (DockerCopyAction copyAction : copyActions) {
+            if (!copyAction.isEmpty()) {
+                getProject().delete(getDestFile().getParentFile().toPath().resolve(copyAction.getTemporaryDirectory())
+                        .toFile());
+                getProject().copy(copySpec -> {
+                    copySpec.with(copyAction.getCopySpec());
+                    copySpec.into(getDestFile().getParentFile());
+                });
+                getInstructions().add(copyAction.getCopyInstruction());
+            }
+        }
+
+        super.create();
+    }
+
+}

--- a/src/main/java/eu/xenit/gradle/tasks/DockerfileWithCopyTask.java
+++ b/src/main/java/eu/xenit/gradle/tasks/DockerfileWithCopyTask.java
@@ -1,9 +1,7 @@
 package eu.xenit.gradle.tasks;
 
 import com.bmuschko.gradle.docker.tasks.image.Dockerfile;
-import java.io.File;
 import java.nio.file.Path;
-import org.gradle.api.Action;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.TaskAction;
@@ -18,7 +16,7 @@ public class DockerfileWithCopyTask extends Dockerfile {
         return "copyFile/"+copyFileCounter;
     }
 
-    public void copyFile(File file, String destinationInImage) {
+    public void copyFile(java.io.File file, String destinationInImage) {
         String stagingDirectory = createCopyFileStagingDirectory();
         copyFileCopySpec.into(stagingDirectory, copySpec -> {
             copySpec.from(file);

--- a/src/main/java/eu/xenit/gradle/tasks/DockerfileWithCopyTask.java
+++ b/src/main/java/eu/xenit/gradle/tasks/DockerfileWithCopyTask.java
@@ -4,6 +4,7 @@ import com.bmuschko.gradle.docker.tasks.image.Dockerfile;
 import java.nio.file.Path;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskAction;
 
 public class DockerfileWithCopyTask extends Dockerfile {
@@ -42,8 +43,8 @@ public class DockerfileWithCopyTask extends Dockerfile {
     @TaskAction
     @Override
     public void create() {
-        Path dockerfileDirectory = getDestFile().getParentFile().toPath();
-        Path copyFileDirectory = dockerfileDirectory.resolve("copyFile");
+        Provider<Path> dockerfileDirectory = getDestFile().map(f -> f.getAsFile().getParentFile().toPath());
+        Provider<Path> copyFileDirectory = dockerfileDirectory.map(p -> p.resolve("copyFile"));
         getProject().delete(copyFileDirectory);
         getProject().copy(copySpec -> {
             copySpec.with(copyFileCopySpec);

--- a/src/main/java/eu/xenit/gradle/tasks/DockerfileWithWarsTask.java
+++ b/src/main/java/eu/xenit/gradle/tasks/DockerfileWithWarsTask.java
@@ -32,7 +32,7 @@ import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.util.GradleVersion;
 
-public class DockerfileWithWarsTask extends Dockerfile implements LabelConsumerTask {
+public class DockerfileWithWarsTask extends DockerfileWithCopyTask implements LabelConsumerTask {
 
     public static final String MESSAGE_BASE_IMAGE_NOT_SET = "Base image not set. You need to configure your base image to build docker images.";
     /**


### PR DESCRIPTION
Added 2 overloads for `Dockerfile.copyFile`, with `File, String` and `FileCollection, String`.

In the original `Dockerfile` class, there only is a `copyFile` method that takes `String, String`, which directly adds a COPY instruction. In that case, the file(s) must be present in the build context (the directory where the Dockerfile lives)

The overloads that function, so you can pass any `File` or `FileCollection`. The files will automatically be copied to a folder inside the build context, so they can be added to the image.

Fixes #42 