### PR TITLE
Patch up smartCopy to work when copying directory trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## Version 4.1.1 - 2019-09-26
+
+### Fixes
+
+ * [#66](https://github.com/xenit-eu/alfresco-docker-gradle-plugin/issues/66) - smartCopy has unexpected behaviour with copying folder
+
 ## Version 4.1.0 - 2019-09-24
 
 ### Added

--- a/src/integrationTest/examples/add-files-dockerfile/build.gradle
+++ b/src/integrationTest/examples/add-files-dockerfile/build.gradle
@@ -20,10 +20,12 @@ dockerAlfresco {
 }
 
 createDockerFile {
-    smartCopy "build.gradle", "/opt/build.gradle"
-    runCommand "mkdir -p /opt/gradle/test-src"
-    smartCopy files("directory"), "/opt/gradle/test-src"
     smartCopy file("test.sh"), "/"
+    runCommand "mkdir -p /opt/gradle/test-src-1 /opt/gradle/test-src-2 /opt/gradle/test-src-3"
+    smartCopy "build.gradle", "/opt/build.gradle"
+    smartCopy files("directory"), "/opt/gradle/test-src-1"
+    smartCopy "directory", "/opt/gradle/test-src-2"
+    smartCopy "directory", "/opt/gradle/test-src-3/"
     runCommand "chmod +x /test.sh"
 }
 

--- a/src/integrationTest/examples/add-files-dockerfile/test.sh
+++ b/src/integrationTest/examples/add-files-dockerfile/test.sh
@@ -1,4 +1,9 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 stat /opt/build.gradle || exit 1
-stat /opt/gradle/test-src/blah/x || exit 1
+stat /opt/gradle/test-src-1/blah/x || exit 1
+stat /opt/gradle/test-src-1/zz || exit 1
+stat /opt/gradle/test-src-2/blah/x || exit 1
+stat /opt/gradle/test-src-2/zz || exit 1
+stat /opt/gradle/test-src-3/blah/x || exit 1
+stat /opt/gradle/test-src-3/zz || exit 1
 exit 0

--- a/src/main/java/eu/xenit/gradle/tasks/DockerfileWithWarsTask.java
+++ b/src/main/java/eu/xenit/gradle/tasks/DockerfileWithWarsTask.java
@@ -211,7 +211,7 @@ public class DockerfileWithWarsTask extends DockerfileWithCopyTask implements La
      */
     @Deprecated
     public void setShareWar(java.io.File shareWar) {
-        Deprecation.warnDeprecatedReplacedBy("addWar(\"alfresco\", alfrescoWar)");
+        Deprecation.warnDeprecatedReplacedBy("addWar(\"share\", alfrescoWar)");
         addWar("share", shareWar);
     }
 


### PR DESCRIPTION
When using copySpec to copy a file or directory, the behavior is different depending on if a file or directory is being copied.
Patch up this difference, so when a directory is used with smartCopy, its contents are actually copied instead of a file inside the directory with the same name of the directory.

Fixes #66