### PR TITLE
Implement global truezip lock around all operations that use truezip.

### DIFF
--- a/src/integrationTest/java/eu/xenit/gradle/testrunner/AbstractIntegrationTest.java
+++ b/src/integrationTest/java/eu/xenit/gradle/testrunner/AbstractIntegrationTest.java
@@ -92,7 +92,6 @@ public abstract class AbstractIntegrationTest {
                 .withArguments(task, "--stacktrace", "--rerun-tasks", "--info")
                 .withGradleVersion(gradleVersion)
                 .withPluginClasspath()
-                .withDebug(true)
                 .forwardOutput();
     }
 

--- a/src/main/java/eu/xenit/gradle/tasks/Util.java
+++ b/src/main/java/eu/xenit/gradle/tasks/Util.java
@@ -13,22 +13,33 @@ import java.util.function.Consumer;
 
 class Util {
 
+    private static final Object TVFS_LOCK = new Object();
+
+    static void withGlobalTvfsLock(Runnable runnable) {
+        Objects.requireNonNull(runnable);
+        synchronized (TVFS_LOCK) {
+            runnable.run();
+        }
+    }
+
     static void withWar(File warFile, Consumer<TFile> closure) {
         Objects.requireNonNull(warFile, "warFile");
         Objects.requireNonNull(closure, "closure");
+        withGlobalTvfsLock(() -> {
             TConfig config = TConfig.get();
             config.setArchiveDetector(new TArchiveDetector("war|amp", new JarDriver(IOPoolLocator.SINGLETON)));
             TFile archive = new TFile(warFile);
-        try {
-            closure.accept(archive);
-        } finally {
             try {
-                TVFS.umount(archive);
-            } catch (FsSyncException ignored) {
-                // This exception is intentionally ignored.
-                // Throwing exceptions in a finally block would swallow the original exception
-                // And it is no big deal if the archive can not be unmounted now, it will be unmounted during process shutdown anyways
+                closure.accept(archive);
+            } finally {
+                try {
+                    TVFS.umount(archive);
+                } catch (FsSyncException ignored) {
+                    // This exception is intentionally ignored.
+                    // Throwing exceptions in a finally block would swallow the original exception
+                    // And it is no big deal if the archive can not be unmounted now, it will be unmounted during process shutdown anyways
+                }
             }
-        }
+        });
     }
 }


### PR DESCRIPTION
We think raceconditions in concurrent truezip usage result in hard to diagnose issues like #72.

Maybe fixes #72 