### PR TITLE
Add plugin classpath checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,25 @@ task buildXYZDockerImage(type: DockerBuildImage) {
 }
 ```
 
+> **Important:** Because Gradle uses plugin classpath isolation, this plugin needs to be present on the root project
+> (or on a common parent of the docker-compose subproject and the subprojects that build docker images)
+> 
+> You can add the plugin to the root project without applying it by using `apply false`.
+>
+> ```groovy
+> plugins {
+>     id "eu.xenit.docker-compose" version "5.0.0" apply false
+> }
+> ```
+> 
+> In the subprojects, you can then apply plugins without specifying versions.
+>
+> ```groovy
+> plugins {
+>     id "eu.xenit.docker-compose"
+> }
+> ```
+
 #### Environment variable naming
 
 To generate an environment name for a docker image of a task, we concatenate project name, `_`, task name, `_DOCKER_IMAGE`.

--- a/src/main/java/eu/xenit/gradle/docker/DockerConfigPlugin.java
+++ b/src/main/java/eu/xenit/gradle/docker/DockerConfigPlugin.java
@@ -19,6 +19,8 @@ import org.gradle.util.GradleVersion;
  */
 public class DockerConfigPlugin implements Plugin<Project> {
 
+    public static final String PLUGIN_ID = "eu.xenit.docker-config";
+
     @Override
     public void apply(Project project) {
         if (GradleVersion.current().compareTo(GradleVersion.version("5.2")) < 0) {

--- a/src/main/java/eu/xenit/gradle/docker/DockerPlugin.java
+++ b/src/main/java/eu/xenit/gradle/docker/DockerPlugin.java
@@ -8,6 +8,8 @@ import org.gradle.api.Project;
  */
 public class DockerPlugin implements Plugin<Project> {
 
+    public static final String PLUGIN_ID = "eu.xenit.docker";
+
     @Override
     public void apply(Project project) {
         project.getPluginManager().apply(DockerConfigPlugin.class);

--- a/src/main/java/eu/xenit/gradle/docker/alfresco/DockerAlfrescoPlugin.java
+++ b/src/main/java/eu/xenit/gradle/docker/alfresco/DockerAlfrescoPlugin.java
@@ -21,6 +21,8 @@ import org.gradle.api.artifacts.Configuration;
  */
 public class DockerAlfrescoPlugin implements Plugin<Project> {
 
+    public static final String PLUGIN_ID = "eu.xenit.docker-alfresco";
+
     public static final String BASE_ALFRESCO_WAR = "baseAlfrescoWar";
     public static final String ALFRESCO_AMP = "alfrescoAmp";
     public static final String BASE_SHARE_WAR = "baseShareWar";

--- a/src/main/java/eu/xenit/gradle/docker/compose/DockerComposeAutoPlugin.java
+++ b/src/main/java/eu/xenit/gradle/docker/compose/DockerComposeAutoPlugin.java
@@ -5,6 +5,8 @@ import org.gradle.api.Project;
 
 public class DockerComposeAutoPlugin implements Plugin<Project> {
 
+    public static final String PLUGIN_ID = "eu.xenit.docker-compose.auto";
+
     @Override
     public void apply(Project project) {
         project.getPlugins().withType(DockerComposePlugin.class, dockerComposePlugin -> {

--- a/src/main/java/eu/xenit/gradle/docker/compose/DockerComposeConvention.java
+++ b/src/main/java/eu/xenit/gradle/docker/compose/DockerComposeConvention.java
@@ -5,10 +5,10 @@ import org.gradle.api.Project;
 import org.gradle.api.tasks.TaskProvider;
 
 public interface DockerComposeConvention {
-    void fromBuildImage(String environmentVariable, TaskProvider<DockerBuildImage> buildImageTaskProvider);
+    void fromBuildImage(String environmentVariable, TaskProvider<? extends DockerBuildImage> buildImageTaskProvider);
     void fromBuildImage(String environmentVariable, DockerBuildImage buildImage);
 
-    void fromBuildImage(TaskProvider<DockerBuildImage> buildImageTaskProvider);
+    void fromBuildImage(TaskProvider<? extends DockerBuildImage> buildImageTaskProvider);
     void fromBuildImage(DockerBuildImage buildImage);
 
 

--- a/src/main/java/eu/xenit/gradle/docker/compose/DockerComposeConventionImpl.java
+++ b/src/main/java/eu/xenit/gradle/docker/compose/DockerComposeConventionImpl.java
@@ -1,21 +1,25 @@
 package eu.xenit.gradle.docker.compose;
 
 import com.avast.gradle.dockercompose.ComposeSettings;
+import com.bmuschko.gradle.docker.DockerRemoteApiPlugin;
 import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage;
 import eu.xenit.gradle.docker.alfresco.DockerAlfrescoPlugin;
 import eu.xenit.gradle.docker.DockerPlugin;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.tasks.TaskCollection;
 import org.gradle.api.tasks.TaskProvider;
 
 public class DockerComposeConventionImpl implements DockerComposeConvention {
 
     private final ComposeSettings composeSettings;
+    private final PluginClasspathChecker pluginClasspathChecker;
     static final String CONFIGURE_COMPOSE_ACTION_NAME = "Configure docker-compose image";
 
     public DockerComposeConventionImpl(ComposeSettings composeSettings) {
         this.composeSettings = composeSettings;
+        this.pluginClasspathChecker = new PluginClasspathChecker(composeSettings.getProject());
     }
 
     private void configureComposeDependencies(Object dependencies) {
@@ -30,18 +34,17 @@ public class DockerComposeConventionImpl implements DockerComposeConvention {
         });
     }
 
-    private void configureBuildImageTask(TaskProvider<? extends DockerBuildImage> buildImageTaskProvider,
+    private void configureBuildImageTask(TaskProvider<? extends Task> buildImageTaskProvider,
             Action<? super DockerBuildImage> action) {
         buildImageTaskProvider.configure(dockerBuildImage -> {
-            dockerBuildImage.doLast(CONFIGURE_COMPOSE_ACTION_NAME, t -> {
-                action.execute(dockerBuildImage);
-            });
+            configureBuildImageTask(dockerBuildImage, action);
         });
     }
 
-    private void configureBuildImageTask(DockerBuildImage buildImage, Action<? super DockerBuildImage> action) {
-        buildImage.doLast(CONFIGURE_COMPOSE_ACTION_NAME, t -> {
-            action.execute(buildImage);
+    private void configureBuildImageTask(Task buildImage, Action<? super DockerBuildImage> action) {
+        DockerBuildImage dockerBuildImage = pluginClasspathChecker.checkTask(DockerBuildImage.class, buildImage);
+        dockerBuildImage.doLast(CONFIGURE_COMPOSE_ACTION_NAME, t -> {
+            action.execute(dockerBuildImage);
         });
     }
 
@@ -84,7 +87,11 @@ public class DockerComposeConventionImpl implements DockerComposeConvention {
         configureBuildImageTask(buildImage, createSetComposeEnvironmentFromPathAction());
     }
 
-    private void fromProjectBuildImage(DockerBuildImage buildImage) {
+    public void fromBuildImage(Task buildImage) {
+        fromBuildImage(pluginClasspathChecker.checkTask(DockerBuildImage.class, buildImage));
+    }
+
+    private void fromProjectBuildImage(Task buildImage) {
         configureBuildImageTask(buildImage, createSetComposeEnvironmentFromPathAction());
     }
 
@@ -95,14 +102,16 @@ public class DockerComposeConventionImpl implements DockerComposeConvention {
         dockerBuildImages.configureEach(this::fromProjectBuildImage);
 
         // Register shortened environment variables for `buildDockerImage` tasks created with the docker or docker-alfresco plugin
-        project.getPlugins().withType(DockerPlugin.class, plugin -> {
+        pluginClasspathChecker.withPlugin(project, DockerPlugin.class, DockerPlugin.PLUGIN_ID, plugin -> {
             String environmentName = Util.safeEnvironmentVariableName(project.getPath().substring(1)) + "_DOCKER_IMAGE";
             fromBuildImage(environmentName, project.getTasks().named("buildDockerImage", DockerBuildImage.class));
         });
-        project.getPlugins().withType(DockerAlfrescoPlugin.class, plugin -> {
+        pluginClasspathChecker.withPlugin(project, DockerAlfrescoPlugin.class, DockerAlfrescoPlugin.PLUGIN_ID, plugin -> {
             String environmentName = Util.safeEnvironmentVariableName(project.getPath().substring(1)) + "_DOCKER_IMAGE";
             fromBuildImage(environmentName, project.getTasks().named("buildDockerImage", DockerBuildImage.class));
         });
+        // Check plugin classpath for docker remote api plugin
+        pluginClasspathChecker.checkPlugin(project, DockerRemoteApiPlugin.class, "com.bmuschko.docker-remote-api");
     }
 
     @Override

--- a/src/main/java/eu/xenit/gradle/docker/compose/DockerComposeConventionImpl.java
+++ b/src/main/java/eu/xenit/gradle/docker/compose/DockerComposeConventionImpl.java
@@ -30,7 +30,7 @@ public class DockerComposeConventionImpl implements DockerComposeConvention {
         });
     }
 
-    private void configureBuildImageTask(TaskProvider<DockerBuildImage> buildImageTaskProvider,
+    private void configureBuildImageTask(TaskProvider<? extends DockerBuildImage> buildImageTaskProvider,
             Action<? super DockerBuildImage> action) {
         buildImageTaskProvider.configure(dockerBuildImage -> {
             dockerBuildImage.doLast(CONFIGURE_COMPOSE_ACTION_NAME, t -> {
@@ -59,22 +59,26 @@ public class DockerComposeConventionImpl implements DockerComposeConvention {
         };
     }
 
-    public void fromBuildImage(String environmentVariable, TaskProvider<DockerBuildImage> buildImageTaskProvider) {
+    @Override
+    public void fromBuildImage(String environmentVariable, TaskProvider<? extends DockerBuildImage> buildImageTaskProvider) {
         configureComposeDependencies(buildImageTaskProvider);
         configureBuildImageTask(buildImageTaskProvider, createSetComposeEnvironmentAction(environmentVariable));
     }
 
+    @Override
     public void fromBuildImage(String environmentVariable, DockerBuildImage buildImage) {
         configureComposeDependencies(buildImage);
         configureBuildImageTask(buildImage, createSetComposeEnvironmentAction(environmentVariable));
     }
 
-    public void fromBuildImage(TaskProvider<DockerBuildImage> buildImageTaskProvider) {
+    @Override
+    public void fromBuildImage(TaskProvider<? extends DockerBuildImage> buildImageTaskProvider) {
         configureComposeDependencies(buildImageTaskProvider);
         configureComposeDependencies(buildImageTaskProvider);
         configureBuildImageTask(buildImageTaskProvider, createSetComposeEnvironmentFromPathAction());
     }
 
+    @Override
     public void fromBuildImage(DockerBuildImage buildImage) {
         configureComposeDependencies(buildImage);
         configureBuildImageTask(buildImage, createSetComposeEnvironmentFromPathAction());
@@ -84,6 +88,7 @@ public class DockerComposeConventionImpl implements DockerComposeConvention {
         configureBuildImageTask(buildImage, createSetComposeEnvironmentFromPathAction());
     }
 
+    @Override
     public void fromProject(Project project) {
         TaskCollection<DockerBuildImage> dockerBuildImages = project.getTasks().withType(DockerBuildImage.class);
         configureComposeDependencies(dockerBuildImages);
@@ -100,6 +105,7 @@ public class DockerComposeConventionImpl implements DockerComposeConvention {
         });
     }
 
+    @Override
     public void fromProject(String projectName) {
         fromProject(composeSettings.getProject().project(projectName));
     }

--- a/src/main/java/eu/xenit/gradle/docker/compose/DockerComposeExtensionOverride.java
+++ b/src/main/java/eu/xenit/gradle/docker/compose/DockerComposeExtensionOverride.java
@@ -21,7 +21,7 @@ public class DockerComposeExtensionOverride extends ComposeExtension implements 
     }
 
     @Override
-    public void fromBuildImage(String environmentVariable, TaskProvider<DockerBuildImage> buildImageTaskProvider) {
+    public void fromBuildImage(String environmentVariable, TaskProvider<? extends DockerBuildImage> buildImageTaskProvider) {
         dockerComposeConvention.fromBuildImage(environmentVariable, buildImageTaskProvider);
 
     }
@@ -33,7 +33,7 @@ public class DockerComposeExtensionOverride extends ComposeExtension implements 
     }
 
     @Override
-    public void fromBuildImage(TaskProvider<DockerBuildImage> buildImageTaskProvider) {
+    public void fromBuildImage(TaskProvider<? extends DockerBuildImage> buildImageTaskProvider) {
         dockerComposeConvention.fromBuildImage(buildImageTaskProvider);
 
     }

--- a/src/main/java/eu/xenit/gradle/docker/compose/DockerComposePlugin.java
+++ b/src/main/java/eu/xenit/gradle/docker/compose/DockerComposePlugin.java
@@ -5,6 +5,7 @@ import org.gradle.api.Project;
 
 public class DockerComposePlugin implements Plugin<Project> {
 
+    public static final String PLUGIN_ID = "eu.xenit.docker-compose";
     private DockerComposeConvention dockerComposeConvention;
 
     @Override

--- a/src/main/java/eu/xenit/gradle/docker/compose/PluginClasspathChecker.java
+++ b/src/main/java/eu/xenit/gradle/docker/compose/PluginClasspathChecker.java
@@ -113,6 +113,6 @@ public class PluginClasspathChecker {
         }
 
         // It really is a totally different class, just try a cast so we generate a ClassCastException
-        return (T) taskInstance;
+        throw new ClassCastException(String.format("%s cannot be cast to %s", taskInstance.getClass(), taskClass));
     }
 }

--- a/src/main/java/eu/xenit/gradle/docker/compose/PluginClasspathChecker.java
+++ b/src/main/java/eu/xenit/gradle/docker/compose/PluginClasspathChecker.java
@@ -1,0 +1,118 @@
+package eu.xenit.gradle.docker.compose;
+
+import org.gradle.api.Action;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+
+/**
+ * Validates that plugins of an other project are on the same (or parent) classpath of where this plugin is running.
+ * <p>
+ * Gradle isolates classpaths of the `plugins {}` block between sibling projects, but for the cross-project functionality,
+ * we need some plugin and task classes to be identical between projects (so not loaded from different classloaders).
+ * <p>
+ * Not having the same class identity will result in either {@link ClassCastException}, or some tasks that are seemingly ignored.
+ * Receiving such exceptions would be very confusing to the user, so when this case is detected, we pre-emptively throw an exception with a custom message.
+ */
+public class PluginClasspathChecker {
+
+    private final Project project;
+
+    public static class PluginClasspathPollutionException extends ClassCastException {
+
+        private static String createMessage(Project sourceProject, Project targetProject, String identifierType,
+                String identifier) {
+            return String
+                    .format("The '%s' %s has a different class identity in %s than in %s.", identifier, identifierType,
+                            targetProject.toString(), sourceProject.toString());
+        }
+
+        public PluginClasspathPollutionException(Project sourceProject, Project targetProject, String pluginId) {
+            super(createMessage(sourceProject, targetProject, "plugin", pluginId)
+                    + String.format("\nDefine the %s plugin once in your root project to fix this problem.", pluginId));
+        }
+
+        public PluginClasspathPollutionException(Project sourceProject, Project targetProject, Task task) {
+            super(createMessage(sourceProject, targetProject, "task", task.getPath())
+                    + "\nDefine the plugin that created this task once in your root project to fix this problem.");
+        }
+    }
+
+    public PluginClasspathChecker(Project project) {
+        this.project = project;
+    }
+
+    /**
+     * Checks that a plugin {@code pluginId} in the {@code targetProject} has the same class identity as the {@code plugin} class
+     *
+     * This check will only be run when a plugin {@code pluginId} is applied to the project.
+     *
+     * @param targetProject Project to check for the plugin
+     * @param plugin Plugin class (or parent class of the plugin) that must be the class of the {@code pluginId} plugin
+     * @param pluginId Plugin id that will be checked for consistency (at the time the plugin is applied)
+     */
+    public void checkPlugin(Project targetProject, Class<? extends Plugin<Project>> plugin, String pluginId) {
+        withPlugin(targetProject, plugin, pluginId, appliedPlugin -> {
+            // Empty
+        });
+    }
+
+    /**
+     * Checks that a plugin {@code pluginId} in the {@code targetProject} has the same class identity as the {@code plugin} class,
+     * and then runs an action with that plugin.
+     *
+     * This check and action will only be run when a plugin {@code pluginId} is applied to the project.
+     * @param targetProject Project to check for the plugin
+     * @param plugin Plugin class (or parent class of the plugin) that must be the class of the {@code pluginId} plugin
+     * @param pluginId Plugin id that will be checked for consistency (at the time the plugin is applied)
+     * @param action Action to run on the plugin {@code plugin}
+     * @param <T> The specific type of the plugin
+     */
+    public <T extends Plugin<Project>> void withPlugin(Project targetProject, Class<T> plugin, String pluginId,
+            Action<? super T> action) {
+        targetProject.getPlugins().withId(pluginId, appliedPlugin -> {
+            if (!plugin.isAssignableFrom(appliedPlugin.getClass())) {
+                throw new PluginClasspathPollutionException(project, targetProject, pluginId);
+            }
+        });
+        targetProject.getPlugins().withType(plugin, appliedPlugin -> {
+            if (!targetProject.getPluginManager().hasPlugin(pluginId)) {
+                throw new PluginClasspathPollutionException(project, targetProject, pluginId);
+            }
+            action.execute(appliedPlugin);
+        });
+    }
+
+    /**
+     * Checks that a task {@code taskInstance} has the same class identity as {@code taskClass}
+     *
+     * In the case that a task class with the same name ({@link Class#getName()} is detected, but with a different identity,
+     * the {@link PluginClasspathPollutionException} is thrown to indicate a problem with the plugin classpath.
+     *
+     * @param taskClass Task class (or parent class of the task) that must be the type of the {@code taskInstance} instance
+     * @param taskInstance Task instance that will be checked to be of type {@code taskClass}
+     * @param <T> The specific type of the class
+     * @return Task instance that has safely been casted to {@code taskClass}
+     */
+    public <T extends Task> T checkTask(Class<T> taskClass, Task taskInstance) {
+        if (taskClass.isAssignableFrom(taskInstance.getClass())) {
+            return (T) taskInstance;
+        }
+
+        Class<?> taskInstanceClass = taskInstance.getClass();
+
+        while (!taskClass.getName().equals(taskInstanceClass.getName()) && !taskInstanceClass
+                .isAssignableFrom(taskClass)) {
+            taskInstanceClass = taskInstanceClass.getSuperclass();
+        }
+        // The names equal, but the identities don't OR we went so far that we got to a class that is the parent of our taskClass (some gradle base class or Object)
+
+        // If the names are equal now, so this is plugin classpath pollution
+        if (taskClass.getName().equals(taskInstanceClass.getName())) {
+            throw new PluginClasspathPollutionException(project, taskInstance.getProject(), taskInstance);
+        }
+
+        // It really is a totally different class, just try a cast so we generate a ClassCastException
+        return (T) taskInstance;
+    }
+}

--- a/src/main/java/eu/xenit/gradle/docker/compose/PluginClasspathPollutionException.java
+++ b/src/main/java/eu/xenit/gradle/docker/compose/PluginClasspathPollutionException.java
@@ -1,0 +1,28 @@
+package eu.xenit.gradle.docker.compose;
+
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+
+public class PluginClasspathPollutionException extends ClassCastException {
+
+    private static String createMessage(Project sourceProject, Project targetProject, String identifierType,
+            String identifier) {
+        return String
+                .format("The '%s' %s has a different class identity in %s than in %s.", identifier, identifierType,
+                        targetProject.toString(), sourceProject.toString());
+    }
+
+    public PluginClasspathPollutionException(String message) {
+        super(message);
+    }
+
+    PluginClasspathPollutionException(Project sourceProject, Project targetProject, String pluginId) {
+        this(createMessage(sourceProject, targetProject, "plugin", pluginId)
+                + String.format("\nDefine the %s plugin once in your root project to fix this problem.", pluginId));
+    }
+
+    PluginClasspathPollutionException(Project sourceProject, Project targetProject, Task task) {
+        this(createMessage(sourceProject, targetProject, "task", task.getPath())
+                + "\nDefine the plugin that created this task once in your root project to fix this problem.");
+    }
+}

--- a/src/test/java/eu/xenit/gradle/docker/compose/PluginClasspathCheckerTest.java
+++ b/src/test/java/eu/xenit/gradle/docker/compose/PluginClasspathCheckerTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertTrue;
 
 import eu.xenit.gradle.docker.DockerPlugin;
 import eu.xenit.gradle.docker.alfresco.tasks.MergeWarsTask;
-import eu.xenit.gradle.docker.compose.PluginClasspathChecker.PluginClasspathPollutionException;
 import eu.xenit.gradle.docker.tasks.internal.DockerBuildImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -146,7 +145,8 @@ public class PluginClasspathCheckerTest {
         assertTrue(projectB.getPlugins().hasPlugin(DockerPlugin.PLUGIN_ID));
 
         expectedException.expect(PluginClasspathPollutionException.class);
-        expectedException.expectMessage(new PluginClasspathPollutionException(projectA, projectB, DockerPlugin.PLUGIN_ID).getMessage());
+        expectedException.expectMessage(
+                new PluginClasspathPollutionException(projectA, projectB, DockerPlugin.PLUGIN_ID).getMessage());
 
         classpathChecker.checkPlugin(projectB, dockerPluginA, DockerPlugin.PLUGIN_ID);
     }
@@ -197,7 +197,8 @@ public class PluginClasspathCheckerTest {
         projectB.evaluate();
 
         expectedException.expect(PluginClasspathPollutionException.class);
-        expectedException.expectMessage(new PluginClasspathPollutionException(projectA, projectB, projectB.getTasks().getByName("dockerBuildImage")).getMessage());
+        expectedException.expectMessage(new PluginClasspathPollutionException(projectA, projectB,
+                projectB.getTasks().getByName("dockerBuildImage")).getMessage());
 
         classpathChecker.checkTask(taskA, projectB.getTasks().getByName("dockerBuildImage"));
     }

--- a/src/test/java/eu/xenit/gradle/docker/compose/PluginClasspathCheckerTest.java
+++ b/src/test/java/eu/xenit/gradle/docker/compose/PluginClasspathCheckerTest.java
@@ -1,0 +1,224 @@
+package eu.xenit.gradle.docker.compose;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertTrue;
+
+import eu.xenit.gradle.docker.DockerPlugin;
+import eu.xenit.gradle.docker.alfresco.tasks.MergeWarsTask;
+import eu.xenit.gradle.docker.compose.PluginClasspathChecker.PluginClasspathPollutionException;
+import eu.xenit.gradle.docker.tasks.internal.DockerBuildImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.function.Supplier;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class PluginClasspathCheckerTest {
+
+
+    private static class CustomClassLoader extends ClassLoader {
+
+        private ClassLoader currentLoader;
+
+        public CustomClassLoader(ClassLoader parent, ClassLoader currentLoader) {
+            super(parent);
+            this.currentLoader = currentLoader;
+        }
+
+        @Override
+        public Class<?> findClass(String name) throws ClassNotFoundException {
+            if (!name.startsWith("eu.xenit.gradle.docker.")) {
+                return currentLoader.loadClass(name);
+            }
+            byte[] bt = loadClassData(name);
+            return defineClass(name, bt, 0, bt.length);
+        }
+
+        @Override
+        protected URL findResource(String s) {
+            return currentLoader.getResource(s);
+        }
+
+        @Override
+        protected Enumeration<URL> findResources(String s) throws IOException {
+            return currentLoader.getResources(s);
+        }
+
+        private byte[] loadClassData(String className) throws ClassNotFoundException {
+            //read class
+            InputStream is = currentLoader.getResourceAsStream(className.replace(".", "/") + ".class");
+            ByteArrayOutputStream byteSt = new ByteArrayOutputStream();
+            //write into byte
+            int len = 0;
+            try {
+                while ((len = is.read()) != -1) {
+                    byteSt.write(len);
+                }
+            } catch (IOException e) {
+                throw new ClassNotFoundException(className);
+            }
+            //convert into byte array
+            return byteSt.toByteArray();
+        }
+
+    }
+
+    private ClassLoader classLoaderA;
+    private ClassLoader classLoaderB;
+
+    private Class<Plugin<Project>> dockerPluginA;
+    private Class<Plugin<Project>> dockerPluginB;
+
+    private ProjectInternal projectA;
+    private ProjectInternal projectB;
+
+    private PluginClasspathChecker classpathChecker;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Before
+    public void setupClassLoader() throws ClassNotFoundException {
+        ClassLoader parentClassLoader = DockerPlugin.class.getClassLoader().getParent();
+        classLoaderA = new CustomClassLoader(parentClassLoader, Project.class.getClassLoader());
+        classLoaderB = new CustomClassLoader(parentClassLoader, Project.class.getClassLoader());
+
+        dockerPluginA = loadClassWithClassloader(classLoaderA, DockerPlugin.class);
+        dockerPluginB = loadClassWithClassloader(classLoaderB, DockerPlugin.class);
+
+        projectA = (ProjectInternal) ProjectBuilder.builder().withName("project-a").build();
+        projectB = (ProjectInternal) ProjectBuilder.builder().withName("project-b").build();
+        classpathChecker = new PluginClasspathChecker(projectA);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T, U extends T> Class<T> loadClassWithClassloader(ClassLoader loader, Class<U> type)
+            throws ClassNotFoundException {
+        return (Class<T>) loader.loadClass(type.getName());
+    }
+
+    private <T> T withClassloader(ClassLoader classloader, Supplier<T> producer) {
+        ClassLoader oldLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(classloader);
+            return producer.get();
+        } finally {
+            Thread.currentThread().setContextClassLoader(oldLoader);
+        }
+    }
+
+    @Test
+    public void testCheckPluginSameClasspath() {
+        withClassloader(classLoaderA, () -> {
+            projectB.getPlugins().apply(dockerPluginA);
+            return null;
+        });
+
+        projectA.evaluate();
+        projectB.evaluate();
+
+        assertTrue(projectB.getPlugins().hasPlugin(DockerPlugin.PLUGIN_ID));
+
+        classpathChecker.checkPlugin(projectB, dockerPluginA, DockerPlugin.PLUGIN_ID);
+    }
+
+    @Test
+    public void testCheckPluginDifferentClasspath() {
+        withClassloader(classLoaderB, () -> {
+            projectB.getPlugins().apply(dockerPluginB);
+            return null;
+        });
+
+        projectA.evaluate();
+        projectB.evaluate();
+
+        assertTrue(projectB.getPlugins().hasPlugin(DockerPlugin.PLUGIN_ID));
+
+        expectedException.expect(PluginClasspathPollutionException.class);
+        expectedException.expectMessage(new PluginClasspathPollutionException(projectA, projectB, DockerPlugin.PLUGIN_ID).getMessage());
+
+        classpathChecker.checkPlugin(projectB, dockerPluginA, DockerPlugin.PLUGIN_ID);
+    }
+
+    @Test
+    public void testCheckTaskSameClasspath() throws ClassNotFoundException {
+        Class<Task> taskA = loadClassWithClassloader(classLoaderA, DockerBuildImage.class);
+
+        projectA.getTasks().register("dockerBuildImage", taskA);
+        projectB.getTasks().register("dockerBuildImage", taskA);
+
+        projectA.evaluate();
+        projectB.evaluate();
+
+        classpathChecker.checkTask(taskA, projectA.getTasks().getByName("dockerBuildImage"));
+        classpathChecker.checkTask(taskA, projectB.getTasks().getByName("dockerBuildImage"));
+    }
+
+    @Test
+    public void testCheckTaskSameClasspathDifferentTaskType() throws ClassNotFoundException {
+        Class<Task> taskA = loadClassWithClassloader(classLoaderA, DockerBuildImage.class);
+        Class<Task> taskAOther = loadClassWithClassloader(classLoaderA, MergeWarsTask.class);
+
+        projectA.getTasks().register("dockerBuildImage", taskA);
+        projectA.getTasks().register("mergeWarsTask", taskAOther);
+
+        projectB.getTasks().register("dockerBuildImage", taskA);
+        projectB.getTasks().register("mergeWarsTask", taskAOther);
+
+        projectA.evaluate();
+        projectB.evaluate();
+
+        expectedException.expect(ClassCastException.class);
+        expectedException.expect(not(instanceOf(PluginClasspathPollutionException.class)));
+
+        classpathChecker.checkTask(taskA, projectB.getTasks().getByName("mergeWarsTask"));
+    }
+
+    @Test
+    public void testCheckTaskDifferentClasspath() throws ClassNotFoundException {
+        Class<Task> taskA = loadClassWithClassloader(classLoaderA, DockerBuildImage.class);
+        Class<Task> taskB = loadClassWithClassloader(classLoaderB, DockerBuildImage.class);
+
+        projectA.getTasks().register("dockerBuildImage", taskA);
+        projectB.getTasks().register("dockerBuildImage", taskB);
+
+        projectA.evaluate();
+        projectB.evaluate();
+
+        expectedException.expect(PluginClasspathPollutionException.class);
+        expectedException.expectMessage(new PluginClasspathPollutionException(projectA, projectB, projectB.getTasks().getByName("dockerBuildImage")).getMessage());
+
+        classpathChecker.checkTask(taskA, projectB.getTasks().getByName("dockerBuildImage"));
+    }
+
+    @Test
+    public void testCheckTaskDifferentClasspathDifferentTaskType() throws ClassNotFoundException {
+        Class<Task> taskA = loadClassWithClassloader(classLoaderA, DockerBuildImage.class);
+        Class<Task> taskAOther = loadClassWithClassloader(classLoaderA, MergeWarsTask.class);
+        Class<Task> taskBOther = loadClassWithClassloader(classLoaderB, MergeWarsTask.class);
+
+        projectA.getTasks().register("mergeWarsTask", taskAOther);
+
+        projectB.getTasks().register("mergeWarsTask", taskBOther);
+
+        projectA.evaluate();
+        projectB.evaluate();
+
+        expectedException.expect(ClassCastException.class);
+        expectedException.expect(not(instanceOf(PluginClasspathPollutionException.class)));
+
+        classpathChecker.checkTask(taskA, projectB.getTasks().getByName("mergeWarsTask"));
+    }
+
+}


### PR DESCRIPTION
Our docker-compose plugin performs cross-project configuration trickery
to retrieve and configure tasks from other projects.
This does not always work well. When a plugin is applied in a `plugins {}`
block, Gradle uses classpath isolation to isolate plugins within each
subproject. This leads to ClassCastExceptions when tasks are passed
around, because the plugin classes do not have the same identity
(classes loaded by different classloaders have a different identity).

However, it is possible to work around this issue: child projects
inherit the classloader from their parent project. By adding the plugin
to a common parent project (for example, the root project), the same
plugin classes are shared in all subprojects. It is possible to specify
`apply false` to only load the plugin in that context, without actually
applying it.

Because users of the plugin are likely not aware this problem and its
solution, we want to throw a custom exception when we detect the case
that two projects use the same plugin, but with a different classloader.

It is not possible to use the current Gradle TestKit framework to write
a test for this behaviour. Gradle TestKit always adds the plugin to a
classloader higher-up the hierarchy, making the plugins available in all
projects of a test build by default.

A killswitch for classpath checking is available in the form of a system property: `eu.xenit.gradle.docker.flags.PluginClasspathChecker.v1.disabled=true`
