### PR TITLE
Configure docker-compose SERVICES_HOST envvar

### DIFF
--- a/src/main/java/eu/xenit/gradle/docker/DockerConfigPlugin.java
+++ b/src/main/java/eu/xenit/gradle/docker/DockerConfigPlugin.java
@@ -60,6 +60,7 @@ public class DockerConfigPlugin implements Plugin<Project> {
             ComposeExtension composeExtension = (ComposeExtension) project.getExtensions().getByName("dockerCompose");
             composeExtension.getUseComposeFiles().add("docker-compose.yml");
             composeExtension.getEnvironment().put("DOCKER_HOST", dockerExtension.getUrl().get());
+            composeExtension.getEnvironment().put("SERVICES_HOST", dockerConfig.getExposeIp());
             composeExtension.getEnvironment().put("DOCKER_IP", dockerConfig.getExposeIp());
             if (dockerConfig.getCertPath() != null) {
                 composeExtension.getEnvironment().put("DOCKER_CERT_PATH", dockerConfig.getCertPath());


### PR DESCRIPTION
The avast docker-compose plugin tries to determine the IP address to use for TCP checks based on `DOCKER_HOST`. If it can't parse `DOCKER_HOST` as URL, it will set it to 'localhost' for checks.
This does not work when `DOCKER_IP` is set to something else (for example, if you want to bind to a private subnet and set the `eu.xenit.docker.expose.ip` property to that value)

Setting `SERVICES_HOST` will override all guessing and will force the IP to be checked to be the ip that is configured in `eu.xenit.docker.expose.ip`.