### PR TITLE
Always unmount truezip virtual fs after usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixes
 
  * [#86](https://github.com/xenit-eu/alfresco-docker-gradle-plugin/pull/86) - Configure docker-compose correctly when expose IP is set to something else than 0.0.0.0 or 127.0.0.1
+ * [#72](https://github.com/xenit-eu/alfresco-docker-gradle-plugin/issues/72)/[#89](https://github.com/xenit-eu/alfresco-docker-gradle-plugin/pull/89) - Truezip IO exception during applyAlfrescoAmp task
 
 ### Changed
 

--- a/src/main/java/eu/xenit/gradle/docker/alfresco/tasks/Util.java
+++ b/src/main/java/eu/xenit/gradle/docker/alfresco/tasks/Util.java
@@ -16,15 +16,42 @@ final class Util {
     private static final Object TVFS_LOCK = new Object();
     private static Exception tvfsUmountException = null;
 
+    private static final String PROP_UMOUNT_EXPERIMENT_BASE = "eu.xenit.gradle.docker.flags.TrueZipUmountExperiment";
+    private static final String PROP_UMOUNT_EXPERIMENT_DISABLE_UMOUNT = PROP_UMOUNT_EXPERIMENT_BASE + ".disableUmount";
+    private static final String PROP_UMOUNT_EXPERIMENT_LOGGING = PROP_UMOUNT_EXPERIMENT_BASE + ".logging";
+    private static final String PROP_UMOUNT_EXPERIMENT_IGNORE_EXCEPTION =
+            PROP_UMOUNT_EXPERIMENT_BASE + ".ignoreException";
+
+    private static boolean isEnabled(String property) {
+        return Boolean.parseBoolean(System.getProperty(property, "false"));
+    }
+
+
     private Util() {
+    }
+
+    private static void umountExperimentLog(String message) {
+        if (isEnabled(PROP_UMOUNT_EXPERIMENT_LOGGING)) {
+            long threadId = Thread.currentThread().getId();
+            System.err.println(String.format("TrueZipUmountExperiment[threadId=%d]: %s", threadId, message));
+        }
     }
 
     static void withGlobalTvfsLock(Runnable runnable) {
         Objects.requireNonNull(runnable);
+        umountExperimentLog("About to acquire global TVFS lock: " + TVFS_LOCK.toString());
         synchronized (TVFS_LOCK) {
+            umountExperimentLog("Acquired global TVFS lock: " + TVFS_LOCK.toString());
             try {
-                if(tvfsUmountException != null) {
-                    throw new IllegalStateException("A previous truezip unmount operation failed. This process (gradle daemon?) is in an undefined state and can not perform truezip operations anymore.", tvfsUmountException);
+                if (tvfsUmountException != null) {
+                    if (isEnabled(PROP_UMOUNT_EXPERIMENT_IGNORE_EXCEPTION)) {
+                        umountExperimentLog(
+                                "Would have thrown IllegalStateException because of previous umount failure");
+                    } else {
+                        throw new IllegalStateException(
+                                "A previous truezip unmount operation failed. This process (gradle daemon?) is in an undefined state and can not perform truezip operations anymore.",
+                                tvfsUmountException);
+                    }
                 }
                 runnable.run();
             } finally {
@@ -32,15 +59,26 @@ final class Util {
                     // After doing something with truezip, unmount all the filesystems.
                     // This code can be run in the gradle daemon, and truezip is keeping global caches there
                     // When files change from underneath it, it may have cached wrong information about it
-                    TVFS.umount();
+                    if (isEnabled(PROP_UMOUNT_EXPERIMENT_DISABLE_UMOUNT)) {
+                        umountExperimentLog("Not calling TVFS.umount() because umount is disabled");
+                    } else {
+                        umountExperimentLog("Calling TVFS.umount()");
+                        TVFS.umount();
+                        umountExperimentLog("Finished TVFS.umount()");
+                    }
                 } catch (FsSyncException e) {
+                    if (isEnabled(PROP_UMOUNT_EXPERIMENT_LOGGING)) {
+                        umountExperimentLog("TVFS.umount() threw exception");
+                        e.printStackTrace(System.err);
+                    }
                     tvfsUmountException = e;
                     // This exception is intentionally ignored.
                     // Throwing exceptions in a finally block would swallow the original exception
-                    // And it is no big deal if the archive can not be unmounted now, it will be unmounted during process shutdown anyways
                 }
             }
+            umountExperimentLog("About to release global TVFS lock: " + TVFS_LOCK.toString());
         }
+        umountExperimentLog("Released global TVFS lock: " + TVFS_LOCK.toString());
     }
 
     static void withWar(File warFile, Consumer<TFile> closure) {


### PR DESCRIPTION
Fixes #72 (maybe)

TrueZip keeps some caches around after it has opened files (and they were not unmounted)
Alfresco MMT code does not unmount the virtual filesystem after it has used them, because they expect it to be thrown away anyways once the process finishes.

However, when build operations are running in a gradle daemon, the same truezip caches are reused across multiple builds. Other tasks that run before the applyAlfrescoAmp task can change AMP files without coordinating with Truezip, leading to the cache being invalid and Truezip searching for archive entries in the wrong place, which hopefully does not contain a valid zip entry header.

Now we make sure to always unmount all files after a Truezip operation, and still keep the global lock while doing so. The lock is also shared across builds, ensuring that no files get unmounted while truezip operations are in progress.

There are also a bunch of debugging properties added in the `eu.xenit.gradle.docker.flags.TrueZipUmountExperiment` namespace that might be useful to have additional logging and change behavior when #72 appears again because we might still have missed the cause of the issue.
