### PR TITLE
Allow to install AMPs inside a WAR that already has AMPs installed.

### DIFF
--- a/src/integrationTest/java/eu/xenit/gradle/testrunner/Reproductions.java
+++ b/src/integrationTest/java/eu/xenit/gradle/testrunner/Reproductions.java
@@ -127,4 +127,9 @@ public class Reproductions extends AbstractIntegrationTest {
     public void testIssue107() throws IOException {
         testProjectFolder(REPRODUCTIONS.resolve("issue-107"), ":functionalTest");
     }
+
+    @Test
+    public void testIssue50() throws IOException {
+        testProjectFolder(REPRODUCTIONS.resolve("issue-50"), ":alfrescoWar");
+    }
 }

--- a/src/integrationTest/reproductions/issue-50/build.gradle
+++ b/src/integrationTest/reproductions/issue-50/build.gradle
@@ -1,0 +1,46 @@
+plugins {
+    id "eu.xenit.amp" version "1.0.1"
+    id "eu.xenit.alfresco" version "1.0.1"
+    id "eu.xenit.docker-alfresco"
+}
+
+sourceSets {
+    moduleA {
+        amp {
+            module([
+                    "module.id"         : "module.a",
+                    "module.version"    : "1.0.0",
+                    "module.title"      : "module.a",
+                    "module.description": "module.a",
+            ])
+        }
+    }
+    moduleB {
+        amp {
+            module([
+                    "module.id"              : "module.b",
+                    "module.version"         : "1.0.0",
+                    "module.title"           : "module.b",
+                    "module.description"     : "module.b",
+                    "module.depends.module.a": "*",
+            ])
+        }
+    }
+    moduleC {
+        amp {
+            module([
+                    "module.id"              : "module.c",
+                    "module.version"         : "1.0.0",
+                    "module.title"           : "module.c",
+                    "module.description"     : "module.c",
+                    "module.depends.module.a": "*",
+                    "module.depends.module.d": "*",
+            ])
+        }
+    }
+}
+
+dependencies {
+    baseAlfrescoWar project(path: ':prepare-alfresco-war', configuration: 'alfrescoWar')
+    alfrescoAmp files(moduleAAmp, moduleBAmp, moduleCAmp)
+}

--- a/src/integrationTest/reproductions/issue-50/prepare-alfresco-war/build.gradle
+++ b/src/integrationTest/reproductions/issue-50/prepare-alfresco-war/build.gradle
@@ -1,0 +1,39 @@
+plugins {
+    id "eu.xenit.amp"
+    id "eu.xenit.alfresco"
+    id "eu.xenit.docker-alfresco"
+}
+
+sourceSets {
+    moduleD {
+        amp {
+            module([
+                    "module.id"         : "module.d",
+                    "module.version"    : "1.0.0",
+                    "module.title"      : "module.d",
+                    "module.description": "module.d",
+            ])
+        }
+    }
+}
+
+repositories {
+    mavenCentral()
+    alfrescoPublic()
+}
+
+configurations {
+    create("alfrescoWar")
+}
+
+artifacts {
+    add("alfrescoWar", tasks.alfrescoWar) {
+        builtBy(tasks.alfrescoWar)
+    }
+}
+
+
+dependencies {
+    baseAlfrescoWar "org.alfresco:content-services-community:6.0.a@war"
+    alfrescoAmp files(moduleDAmp)
+}

--- a/src/integrationTest/reproductions/issue-50/settings.gradle
+++ b/src/integrationTest/reproductions/issue-50/settings.gradle
@@ -1,0 +1,2 @@
+include ':'
+include ':prepare-alfresco-war'

--- a/src/main/java/eu/xenit/gradle/docker/alfresco/DockerAlfrescoPlugin.java
+++ b/src/main/java/eu/xenit/gradle/docker/alfresco/DockerAlfrescoPlugin.java
@@ -159,7 +159,7 @@ public class DockerAlfrescoPlugin implements Plugin<Project> {
         mergeWarsTask.addInputWar(project.provider(baseWar::getSingleFile));
         for (WarLabelOutputTask task : outputTasks) {
             mergeWarsTask.withLabels(task);
-            mergeWarsTask.addInputWar(project.provider(() -> task.getOutputWar().get().getAsFile()));
+            mergeWarsTask.addInputWar(task);
         }
 
         return outputTasks;

--- a/src/main/java/eu/xenit/gradle/docker/alfresco/DockerAlfrescoPlugin.java
+++ b/src/main/java/eu/xenit/gradle/docker/alfresco/DockerAlfrescoPlugin.java
@@ -116,12 +116,7 @@ public class DockerAlfrescoPlugin implements Plugin<Project> {
                     }
                 });
         resolveTask.setGroup(TASK_GROUP);
-        resolveTask.getInputWar().set(project.getLayout().file(project.provider(() -> {
-            if (baseWar.isEmpty()) {
-                return null;
-            }
-            return baseWar.getSingleFile();
-        })));
+        resolveTask.setInputWar(baseWar);
 
         final List<WarEnrichmentTask> tasks = new ArrayList<>();
 
@@ -158,7 +153,6 @@ public class DockerAlfrescoPlugin implements Plugin<Project> {
 
         mergeWarsTask.addInputWar(project.provider(baseWar::getSingleFile));
         for (WarLabelOutputTask task : outputTasks) {
-            mergeWarsTask.withLabels(task);
             mergeWarsTask.addInputWar(task);
         }
 

--- a/src/main/java/eu/xenit/gradle/docker/alfresco/DockerAlfrescoPlugin.java
+++ b/src/main/java/eu/xenit/gradle/docker/alfresco/DockerAlfrescoPlugin.java
@@ -111,6 +111,7 @@ public class DockerAlfrescoPlugin implements Plugin<Project> {
         WarEnrichmentTask resolveTask = project.getTasks()
                 .create("strip" + warName + "War", StripAlfrescoWarTask.class, stripAlfrescoWarTask -> {
                     stripAlfrescoWarTask.addPathToCopy(WarHelperImpl.MANIFEST_FILE);
+                    stripAlfrescoWarTask.addPathToCopy("WEB-INF/classes/alfresco/module/*/module.properties");
                     if (warName.equals(ALFRESCO)) {
                         stripAlfrescoWarTask.addPathToCopy(WarHelperImpl.VERSION_PROPERTIES);
                     }

--- a/src/main/java/eu/xenit/gradle/docker/alfresco/internal/amp/DuplicateModuleException.java
+++ b/src/main/java/eu/xenit/gradle/docker/alfresco/internal/amp/DuplicateModuleException.java
@@ -1,0 +1,29 @@
+package eu.xenit.gradle.docker.alfresco.internal.amp;
+
+public class DuplicateModuleException extends ModuleException {
+
+    private final ModuleInformation moduleA;
+    private final ModuleInformation moduleB;
+
+    DuplicateModuleException(String message, ModuleInformation moduleA, ModuleInformation moduleB) {
+        super(message);
+        this.moduleA = moduleA;
+        this.moduleB = moduleB;
+    }
+
+    public DuplicateModuleException(ModuleInformation moduleA, ModuleInformation moduleB) {
+        this("The module "+ createModuleName(moduleA) + " already exists as " + createModuleName(moduleB), moduleA, moduleB);
+    }
+
+    private static String createModuleName(ModuleInformation moduleInformation) {
+        return moduleInformation.getId() + " version " + moduleInformation.getVersion();
+    }
+
+    public ModuleInformation getModuleB() {
+        return moduleB;
+    }
+
+    public ModuleInformation getModuleA() {
+        return moduleA;
+    }
+}

--- a/src/main/java/eu/xenit/gradle/docker/alfresco/internal/amp/ModuleAlreadyInstalledException.java
+++ b/src/main/java/eu/xenit/gradle/docker/alfresco/internal/amp/ModuleAlreadyInstalledException.java
@@ -1,0 +1,25 @@
+package eu.xenit.gradle.docker.alfresco.internal.amp;
+
+public class ModuleAlreadyInstalledException extends DuplicateModuleException {
+
+    private final ModuleInformation moduleToInstall;
+    private final ModuleInformation existingModule;
+
+    public ModuleAlreadyInstalledException(ModuleInformation moduleToInstall, ModuleInformation existingModule) {
+        super("The module "+ createModuleName(moduleToInstall) + " is already installed as " + createModuleName(existingModule), moduleToInstall, existingModule);
+        this.moduleToInstall = moduleToInstall;
+        this.existingModule = existingModule;
+    }
+
+    private static String createModuleName(ModuleInformation moduleInformation) {
+        return moduleInformation.getId() + " version " + moduleInformation.getVersion();
+    }
+
+    public ModuleInformation getExistingModule() {
+        return existingModule;
+    }
+
+    public ModuleInformation getModuleToInstall() {
+        return moduleToInstall;
+    }
+}

--- a/src/main/java/eu/xenit/gradle/docker/alfresco/internal/amp/ModuleDependencyResolver.java
+++ b/src/main/java/eu/xenit/gradle/docker/alfresco/internal/amp/ModuleDependencyResolver.java
@@ -15,7 +15,10 @@ class ModuleDependencyResolver {
         Map<String, ModuleInformation> moduleIds = new HashMap<>(dependencies.size());
         for (ModuleInformation dependency : dependencies) {
             for (String alias : dependency.getIds()) {
-                moduleIds.put(alias, dependency);
+                ModuleInformation previousDependency = moduleIds.put(alias, dependency);
+                if(previousDependency != null) {
+                    throw new DuplicateModuleException(dependency, previousDependency);
+                }
             }
         }
         return moduleIds;

--- a/src/main/java/eu/xenit/gradle/docker/alfresco/internal/amp/ModuleDependencySorter.java
+++ b/src/main/java/eu/xenit/gradle/docker/alfresco/internal/amp/ModuleDependencySorter.java
@@ -3,10 +3,10 @@ package eu.xenit.gradle.docker.alfresco.internal.amp;
 import de.schlichtherle.truezip.file.TFile;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.alfresco.repo.module.tool.LogOutput;
 import org.alfresco.repo.module.tool.WarHelper;
 import org.alfresco.repo.module.tool.WarHelperImpl;
 import org.alfresco.service.cmr.module.ModuleInstallState;
@@ -16,7 +16,7 @@ public final class ModuleDependencySorter {
     private ModuleDependencySorter() {
     }
 
-    static Set<ModuleInformation> readInstalledModulesFromWar(File war) {
+    private static Set<ModuleInformation> readInstalledModulesFromWar(File war) {
         WarHelper warHelper = new WarHelperImpl(o -> {
             // We do not want to log any output from the WarHelper
         });
@@ -28,7 +28,7 @@ public final class ModuleDependencySorter {
                 .collect(Collectors.toSet());
     }
 
-    static List<ModuleWithDependencies> sortByDependencies(Set<ModuleWithDependencies> modules) {
+    private static List<ModuleWithDependencies> sortByDependencies(Set<ModuleWithDependencies> modules) {
         List<ModuleWithDependencies> orderedDependencyList = new ArrayList<>();
         for (ModuleWithDependencies module : modules) {
             if (!orderedDependencyList.contains(module)) {
@@ -44,20 +44,27 @@ public final class ModuleDependencySorter {
         return orderedDependencyList;
     }
 
-    public static List<ModuleInformation> sortByInstallOrder(Set<File> modules, File warFile) {
-        Set<ModuleInformation> moduleDependencies = modules.stream()
-                .map(ModuleInformationAmp::new)
-                .collect(Collectors.toSet());
-        moduleDependencies.addAll(readInstalledModulesFromWar(warFile));
+    static List<ModuleInformation> sortByInstallOrder(Set<ModuleInformation> modules,
+            Set<ModuleInformation> warModules) {
+        Set<ModuleInformation> moduleDependencies = new HashSet<>(modules);
+        moduleDependencies.addAll(warModules);
+
         ModuleDependencyResolver moduleDependencyResolver = new ModuleDependencyResolver(moduleDependencies);
-        Set<ModuleWithDependencies> moduleWithDependencies = moduleDependencies.stream()
+        Set<ModuleWithDependencies> moduleWithDependencies = modules.stream()
                 .map(moduleDependencyResolver::resolve)
                 .collect(Collectors.toSet());
         List<ModuleWithDependencies> installOrder = sortByDependencies(moduleWithDependencies);
-
         return installOrder.stream()
-                .filter(m -> m.getModuleInformation() instanceof ModuleInformationAmp)
+                .filter(m -> modules.contains(m.getModuleInformation()))
                 .map(ModuleWithDependencies::getModuleInformation)
                 .collect(Collectors.toList());
+    }
+
+    public static List<ModuleInformation> sortByInstallOrder(Set<File> modules, File warFile) {
+        Set<ModuleInformation> informationFromModules = modules.stream()
+                .map(ModuleInformationAmp::new)
+                .collect(Collectors.toSet());
+        Set<ModuleInformation> informationFromWar = readInstalledModulesFromWar(warFile);
+        return sortByInstallOrder(informationFromModules, informationFromWar);
     }
 }

--- a/src/main/java/eu/xenit/gradle/docker/alfresco/internal/amp/ModuleInformation.java
+++ b/src/main/java/eu/xenit/gradle/docker/alfresco/internal/amp/ModuleInformation.java
@@ -10,6 +10,8 @@ public interface ModuleInformation extends Serializable {
 
     String getId();
 
+    String getVersion();
+
     Set<String> getIds();
 
     Set<String> getDependencyModuleIds();

--- a/src/main/java/eu/xenit/gradle/docker/alfresco/internal/amp/ModuleInformationFromModuleDetails.java
+++ b/src/main/java/eu/xenit/gradle/docker/alfresco/internal/amp/ModuleInformationFromModuleDetails.java
@@ -29,4 +29,10 @@ abstract class ModuleInformationFromModuleDetails implements ModuleInformation {
                 .map(ModuleDependency::getDependencyId)
                 .collect(Collectors.toSet());
     }
+
+    @Override
+    public String getVersion() {
+        return getModuleDetails()
+                .getModuleVersionNumber().toString();
+    }
 }

--- a/src/main/java/eu/xenit/gradle/docker/alfresco/tasks/MergeWarsTask.java
+++ b/src/main/java/eu/xenit/gradle/docker/alfresco/tasks/MergeWarsTask.java
@@ -42,4 +42,12 @@ public class MergeWarsTask extends Zip implements LabelConsumerTask, LabelSuppli
     public void addInputWar(Provider<File> inputWar) {
         childWars.from(getProject().provider(() -> getProject().zipTree(inputWar)));
     }
+
+    public void addInputWar(WarOutputTask inputWar) {
+        if(inputWar instanceof WarLabelOutputTask) {
+            withLabels((WarLabelOutputTask)inputWar);
+        }
+        addInputWar(inputWar.getOutputWar().map(f -> f.getAsFile()));
+        dependsOn(inputWar);
+    }
 }

--- a/src/main/java/eu/xenit/gradle/docker/alfresco/tasks/WarInputTask.java
+++ b/src/main/java/eu/xenit/gradle/docker/alfresco/tasks/WarInputTask.java
@@ -13,7 +13,12 @@ public interface WarInputTask extends Task {
     RegularFileProperty getInputWar();
 
     default void setInputWar(FileCollection configuration) {
-        getInputWar().set(configuration::getSingleFile);
+        dependsOn(configuration);
+        getInputWar().set(getProject().getLayout().file(getProject().provider(() -> {
+            if(configuration.isEmpty())
+                return null;
+            return configuration.getSingleFile();
+        })));
     }
 
     default void setInputWar(WarOutputTask task) {

--- a/src/test/java/eu/xenit/gradle/docker/alfresco/internal/amp/DummyModuleInformation.java
+++ b/src/test/java/eu/xenit/gradle/docker/alfresco/internal/amp/DummyModuleInformation.java
@@ -9,9 +9,15 @@ class DummyModuleInformation implements ModuleInformation {
 
     private final String moduleId;
     private final Set<String> moduleDependencies;
+    private final String version;
 
     public DummyModuleInformation(String moduleId, Set<String> moduleDependencies) {
+        this(moduleId, "0.0.0", moduleDependencies);
+    }
+
+    public DummyModuleInformation(String moduleId, String version, Set<String> moduleDependencies) {
         this.moduleId = moduleId;
+        this.version = version;
         this.moduleDependencies = Collections.unmodifiableSet(moduleDependencies);
     }
 
@@ -23,6 +29,11 @@ class DummyModuleInformation implements ModuleInformation {
     @Override
     public String getId() {
         return moduleId;
+    }
+
+    @Override
+    public String getVersion() {
+        return version;
     }
 
     @Override
@@ -57,6 +68,7 @@ class DummyModuleInformation implements ModuleInformation {
     public String toString() {
         return "DummyModuleInformation{" +
                 "moduleId='" + moduleId + '\'' +
+                "version='" + version+ '\'' +
                 '}';
     }
 }

--- a/src/test/java/eu/xenit/gradle/docker/alfresco/internal/amp/DummyModuleInformation.java
+++ b/src/test/java/eu/xenit/gradle/docker/alfresco/internal/amp/DummyModuleInformation.java
@@ -47,24 +47,6 @@ class DummyModuleInformation implements ModuleInformation {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        DummyModuleInformation that = (DummyModuleInformation) o;
-        return moduleId.equals(that.moduleId) &&
-                moduleDependencies.equals(that.moduleDependencies);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(moduleId, moduleDependencies);
-    }
-
-    @Override
     public String toString() {
         return "DummyModuleInformation{" +
                 "moduleId='" + moduleId + '\'' +

--- a/src/test/java/eu/xenit/gradle/docker/alfresco/internal/amp/ModuleDependencyResolverTest.java
+++ b/src/test/java/eu/xenit/gradle/docker/alfresco/internal/amp/ModuleDependencyResolverTest.java
@@ -113,7 +113,19 @@ public class ModuleDependencyResolverTest {
         assertEquals("module.c has a dependency on module.a and module.b",
                 new HashSet<>(Arrays.asList(moduleAWithDependencies, moduleBWithDependencies)),
                 moduleCWithDependencies.getDependencies());
+    }
 
+    @Test(expected = DuplicateModuleException.class)
+    public void resolveDuplicateModules() {
+        Set<ModuleInformation> modules = new HashSet<>();
+        ModuleInformation moduleA = new DummyModuleInformation("module.a", Collections.emptySet());
+        modules.add(moduleA);
+        ModuleInformation moduleB = new DummyModuleInformation("module.b", Collections.singleton(moduleA.getId()));
+        modules.add(moduleB);
+        ModuleInformation moduleBbis = new DummyModuleInformation("module.b", Collections.singleton(moduleA.getId()));
+        modules.add(moduleBbis);
+
+        new ModuleDependencyResolver(Collections.unmodifiableSet(modules));
     }
 
 }

--- a/src/test/java/eu/xenit/gradle/docker/alfresco/internal/amp/ModuleDependencySorterTest.java
+++ b/src/test/java/eu/xenit/gradle/docker/alfresco/internal/amp/ModuleDependencySorterTest.java
@@ -73,4 +73,32 @@ public class ModuleDependencySorterTest {
         assertTrue("module.b is installed before module.c", moduleBIndex < moduleCIndex);
     }
 
+    @Test
+    public void sortDoesNotListWarModules() {
+        Set<ModuleInformation> amps = new HashSet<>();
+        Set<ModuleInformation> warModules = new HashSet<>();
+
+        warModules.add(new DummyModuleInformation("module.a", Collections.emptySet()));
+        amps.add(new DummyModuleInformation("module.b", Collections.emptySet()));
+        amps.add(new DummyModuleInformation("module.c", new HashSet<>(Arrays.asList("module.a", "module.b"))));
+
+        List<ModuleInformation> sortedInInstallationOrder = ModuleDependencySorter.sortByInstallOrder(amps, warModules);
+
+        List<String> modulesToInstall = sortedInInstallationOrder.stream()
+                .map(ModuleInformation::getId)
+                .collect(Collectors.toList());
+
+        assertEquals(Arrays.asList("module.b", "module.c"), modulesToInstall);
+    }
+
+    @Test(expected = ModuleAlreadyInstalledException.class)
+    public void sortRejectsAlreadyInstalledModules() {
+        Set<ModuleInformation> amps = new HashSet<>();
+        Set<ModuleInformation> warModules = new HashSet<>();
+
+        warModules.add(new DummyModuleInformation("module.a", Collections.emptySet()));
+        amps.add(new DummyModuleInformation("module.a", Collections.emptySet()));
+
+        ModuleDependencySorter.sortByInstallOrder(amps, warModules);
+    }
 }

--- a/src/test/java/eu/xenit/gradle/docker/alfresco/internal/amp/ModuleDependencySorterTest.java
+++ b/src/test/java/eu/xenit/gradle/docker/alfresco/internal/amp/ModuleDependencySorterTest.java
@@ -23,56 +23,52 @@ public class ModuleDependencySorterTest {
 
     @Test
     public void sortWithoutDependencies() {
-        Set<ModuleWithDependencies> modules = new HashSet<>();
-        ModuleWithDependencies moduleA = createModuleWithDependencies("module.a", Collections.emptySet());
-        modules.add(moduleA);
-        ModuleWithDependencies moduleB = createModuleWithDependencies("module.b", Collections.emptySet());
-        modules.add(moduleB);
-        ModuleWithDependencies moduleC = createModuleWithDependencies("module.c", Collections.emptySet());
-        modules.add(moduleC);
+        Set<ModuleInformation> modules = new HashSet<>();
+        modules.add(new DummyModuleInformation("module.a", Collections.emptySet()));
+        modules.add(new DummyModuleInformation("module.b", Collections.emptySet()));
+        modules.add(new DummyModuleInformation("module.c", Collections.emptySet()));
 
-        List<ModuleWithDependencies> sortedModules = ModuleDependencySorter.sortByDependencies(modules);
+        List<String> sortedModules = ModuleDependencySorter.sortByInstallOrder(modules, Collections.emptySet()).stream()
+                .map(ModuleInformation::getId)
+                .collect(Collectors.toList());
 
-        assertTrue("Sorted by dependencies contains module.a", sortedModules.contains(moduleA));
-        assertTrue("Sorted by dependencies contains module.b", sortedModules.contains(moduleB));
-        assertTrue("Sorted by dependencies contains module.c", sortedModules.contains(moduleC));
+        assertTrue("Sorted by dependencies contains module.a", sortedModules.contains("module.a"));
+        assertTrue("Sorted by dependencies contains module.b", sortedModules.contains("module.b"));
+        assertTrue("Sorted by dependencies contains module.c", sortedModules.contains("module.c"));
     }
 
     @Test
     public void sortWithSingleDependencies() {
-        Set<ModuleWithDependencies> modules = new HashSet<>();
-        ModuleWithDependencies moduleA = createModuleWithDependencies("module.a", Collections.emptySet());
-        modules.add(moduleA);
-        ModuleWithDependencies moduleB = createModuleWithDependencies("module.b", Collections.singleton(moduleA));
-        modules.add(moduleB);
-        ModuleWithDependencies moduleC = createModuleWithDependencies("module.c", Collections.singleton(moduleB));
-        modules.add(moduleC);
+        Set<ModuleInformation> modules = new HashSet<>();
+        modules.add(new DummyModuleInformation("module.a", Collections.emptySet()));
+        modules.add(new DummyModuleInformation("module.b", Collections.singleton("module.a")));
+        modules.add(new DummyModuleInformation("module.c", Collections.singleton("module.b")));
 
-        List<ModuleWithDependencies> sortedModules = ModuleDependencySorter.sortByDependencies(modules);
+        List<String> sortedModules = ModuleDependencySorter.sortByInstallOrder(modules, Collections.emptySet()).stream()
+                .map(ModuleInformation::getId)
+                .collect(Collectors.toList());
 
-        assertEquals(Arrays.asList(moduleA, moduleB, moduleC), sortedModules);
+        assertEquals(Arrays.asList("module.a", "module.b", "module.c"), sortedModules);
     }
 
     @Test
     public void sortWithMultipleDependencies() {
-        Set<ModuleWithDependencies> modules = new HashSet<>();
-        ModuleWithDependencies moduleA = createModuleWithDependencies("module.a", Collections.emptySet());
-        modules.add(moduleA);
-        ModuleWithDependencies moduleB = createModuleWithDependencies("module.b", Collections.emptySet());
-        modules.add(moduleB);
-        ModuleWithDependencies moduleC = createModuleWithDependencies("module.c",
-                new HashSet<>(Arrays.asList(moduleA, moduleB)));
-        modules.add(moduleC);
+        Set<ModuleInformation> modules = new HashSet<>();
+        modules.add(new DummyModuleInformation("module.a", Collections.emptySet()));
+        modules.add(new DummyModuleInformation("module.b", Collections.emptySet()));
+        modules.add(new DummyModuleInformation("module.c", new HashSet<>(Arrays.asList("module.a", "module.b"))));
 
-        List<ModuleWithDependencies> sortedModules = ModuleDependencySorter.sortByDependencies(modules);
+        List<String> sortedModules = ModuleDependencySorter.sortByInstallOrder(modules, Collections.emptySet()).stream()
+                .map(ModuleInformation::getId)
+                .collect(Collectors.toList());
 
-        assertTrue("module.a is in the sorted modules", sortedModules.contains(moduleA));
-        assertTrue("module.c is in the sorted modules", sortedModules.contains(moduleB));
-        assertTrue("module.c is in the sorted modules", sortedModules.contains(moduleC));
+        assertTrue("module.a is in the sorted modules", sortedModules.contains("module.a"));
+        assertTrue("module.c is in the sorted modules", sortedModules.contains("module.b"));
+        assertTrue("module.c is in the sorted modules", sortedModules.contains("module.c"));
 
-        int moduleAIndex = sortedModules.indexOf(moduleA);
-        int moduleBIndex = sortedModules.indexOf(moduleB);
-        int moduleCIndex = sortedModules.indexOf(moduleC);
+        int moduleAIndex = sortedModules.indexOf("module.a");
+        int moduleBIndex = sortedModules.indexOf("module.b");
+        int moduleCIndex = sortedModules.indexOf("module.c");
         assertTrue("module.a is installed before module.c", moduleAIndex < moduleCIndex);
         assertTrue("module.b is installed before module.c", moduleBIndex < moduleCIndex);
     }


### PR DESCRIPTION
To get this working, I needed to:

1. Fix the dependencies of `stripAlfrescoWar` task: The configuration that is passed to the task should be resolved. Needs a `dependsOn` in case it is a `project()` type dependency.
2. Fix dependencies of `alfrescoWar`/`shareWar`: `applyAlfrescoAmp`, `applyAlfrescoDE` & `applyAlfrescoSM` tasks should be depended on when they are an input to the `alfrescoWar` task, or these tasks would not run.
3. We need ant-style patterns for `StripAlfrescoWarTask`, so we can include all the `module.properties` files that are in the correct location
4. Add checks that you don't reinstall a module that is already installed: The MMT itself just prints a message to stdout and does not fail the build. We want the build to fail when multiple versions of a module are being installed or a module that is already present in the WAR is being installed.

Fixes #50 