### PR TITLE
Update dependency com.bmushko:gradle-docker-plugin to 6.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+ * [] - Update com.bmushko:gradle-docker-plugin to 6.4.0, supports Docker credentials store
+
 ## Version 5.0.4 - 2020-02-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
- * [] - Update com.bmushko:gradle-docker-plugin to 6.4.0, supports Docker credentials store
+ * [#115](https://github.com/xenit-eu/alfresco-docker-gradle-plugin/pull/115) - Update com.bmushko:gradle-docker-plugin to 6.4.0, supports Docker credentials store
 
 ## Version 5.0.4 - 2020-02-28
 

--- a/build.gradle
+++ b/build.gradle
@@ -126,7 +126,7 @@ dependencies {
         exclude group: 'org.slf4j'
     }
 
-    compile 'com.bmuschko:gradle-docker-plugin:6.1.2'
+    compile 'com.bmuschko:gradle-docker-plugin:6.4.0'
     compile 'com.avast.gradle:gradle-docker-compose-plugin:0.10.7'
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile gradleTestKit()


### PR DESCRIPTION
Updating `com.bmushko:gradle-docker-plugin` dependency now that https://github.com/bmuschko/gradle-docker-plugin/pull/913 is merged - thanks @vierbergenlars :medal_sports: 

I can confirm that with this dependency bump, the docker-repo credentials from my `~/.docker/config.json` are now effectively used :+1: 