### PR TITLE
Throw when using pushDockerImage without tags

### DIFF
--- a/src/integrationTest/java/eu/xenit/gradle/testrunner/Reproductions.java
+++ b/src/integrationTest/java/eu/xenit/gradle/testrunner/Reproductions.java
@@ -1,6 +1,7 @@
 package eu.xenit.gradle.testrunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import eu.xenit.gradle.docker.alfresco.tasks.DockerfileWithWarsTask;
@@ -9,6 +10,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
 import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.Test;
 
@@ -131,5 +134,16 @@ public class Reproductions extends AbstractIntegrationTest {
     @Test
     public void testIssue50() throws IOException {
         testProjectFolder(REPRODUCTIONS.resolve("issue-50"), ":alfrescoWar");
+    }
+
+    @Test
+    public void testIssue114() throws IOException {
+        BuildResult result = getGradleRunner(REPRODUCTIONS.resolve("issue-114"), ":pushDockerImage").buildAndFail();
+
+        BuildTask pushDockerImage = result.task(":pushDockerImage");
+        assertNotNull(pushDockerImage);
+        assertEquals(TaskOutcome.FAILED, pushDockerImage.getOutcome());
+
+
     }
 }

--- a/src/integrationTest/reproductions/issue-114/build.gradle
+++ b/src/integrationTest/reproductions/issue-114/build.gradle
@@ -1,0 +1,23 @@
+plugins {
+    id 'eu.xenit.docker-alfresco'
+}
+
+repositories {
+    mavenCentral()
+    jcenter()
+    maven {
+        url "https://artifacts.alfresco.com/nexus/content/groups/public/"
+    }
+}
+
+dependencies {
+    baseAlfrescoWar "org.alfresco:content-services-community:6.0.7-ga@war"
+}
+
+dockerAlfresco {
+    baseImage = "alfresco/alfresco-content-repository-community:6.0.7-ga"
+    leanImage = true
+    dockerBuild {
+        repository = 'issue-107'
+    }
+}

--- a/src/main/java/eu/xenit/gradle/docker/DockerBuildBehavior.java
+++ b/src/main/java/eu/xenit/gradle/docker/DockerBuildBehavior.java
@@ -2,14 +2,13 @@ package eu.xenit.gradle.docker;
 
 import static eu.xenit.gradle.docker.internal.git.JGitInfoProvider.GetProviderForProject;
 
-import com.avast.gradle.dockercompose.ComposeExtension;
-import com.bmuschko.gradle.docker.tasks.image.DockerPushImage;
 import com.bmuschko.gradle.docker.tasks.image.Dockerfile;
 import eu.xenit.gradle.docker.compose.DockerComposePlugin;
 import eu.xenit.gradle.docker.internal.JenkinsUtil;
-import eu.xenit.gradle.docker.tasks.internal.DockerBuildImage;
 import eu.xenit.gradle.docker.internal.git.CannotConvertToUrlException;
 import eu.xenit.gradle.docker.internal.git.GitInfoProvider;
+import eu.xenit.gradle.docker.tasks.internal.DockerBuildImage;
+import eu.xenit.gradle.docker.tasks.internal.DockerPushImage;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/eu/xenit/gradle/docker/tasks/internal/DockerPushImage.java
+++ b/src/main/java/eu/xenit/gradle/docker/tasks/internal/DockerPushImage.java
@@ -1,0 +1,26 @@
+package eu.xenit.gradle.docker.tasks.internal;
+
+import java.util.Set;
+import org.gradle.api.Action;
+import org.gradle.api.Task;
+
+public class DockerPushImage extends com.bmuschko.gradle.docker.tasks.image.DockerPushImage {
+
+    public DockerPushImage() {
+        prependParallelSafeAction(new CheckDockerTagsAction());
+    }
+
+    private final class CheckDockerTagsAction implements Action<Task> {
+
+        @Override
+        public void execute(Task task) {
+            boolean isEmpty = DockerPushImage.this.getImages()
+                    .map(Set::isEmpty)
+                    .getOrElse(true);
+            if (isEmpty) {
+                throw new NoImagesConfiguredException();
+            }
+        }
+    }
+
+}

--- a/src/main/java/eu/xenit/gradle/docker/tasks/internal/NoImagesConfiguredException.java
+++ b/src/main/java/eu/xenit/gradle/docker/tasks/internal/NoImagesConfiguredException.java
@@ -1,0 +1,9 @@
+package eu.xenit.gradle.docker.tasks.internal;
+
+import org.gradle.api.GradleException;
+
+public class NoImagesConfiguredException extends GradleException {
+    public NoImagesConfiguredException() {
+        super("Pushing no docker images is not a valid action. Please configure some images to push.");
+    }
+}

--- a/src/test/java/eu/xenit/gradle/docker/alfresco/DockerAlfrescoPluginTest.java
+++ b/src/test/java/eu/xenit/gradle/docker/alfresco/DockerAlfrescoPluginTest.java
@@ -35,16 +35,8 @@ public class DockerAlfrescoPluginTest {
         return project;
     }
 
-
     @Rule
     public final TemporaryFolder testProjectFolder = new TemporaryFolder();
-    private File buildFile;
-
-    @Before
-    public void setup() throws IOException {
-        buildFile = testProjectFolder.newFile("build.gradle");
-    }
-
 
     @Test
     public void testApplyAlfrescoAmps() {


### PR DESCRIPTION
It is possible to invoke the pushDockerImage task, even when you have no
tags configured at all. This will result in pushDockerImage completing
succesfully by doing nothing.
This may lead to the user thinking that images were pushed succesfully
when in fact nothing has been pushed.
Since this task is only used for pushing to a docker registry, it is
okay to throw an error when no images are given to it.
The buildDockerImage task can still be used to build images that are
used only for testing locally and do not have to be pushed.