### PR TITLE
Run tests on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ init:
         $config.exposeDockerAPIOnTCP2375=$true
         $config | ConvertTo-Json | Set-Content "C:\Users\appveyor\AppData\Roaming\Docker\settings.json" 
     - ps: Start-Service "com.docker.service"
-    - cmd: '"C:\\Program Files\\Docker\\Docker\\Docker Desktop.exe"'
+    - ps: '& "C:\\Program Files\\Docker\\Docker\\Docker Desktop.exe"'
     - ps: Switch-DockerLinux
     - cmd: docker -H tcp://localhost:2375 info
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+init:
+    - ps: Stop-Service "com.docker.service"
+    - ps: Stop-Process -Name "Docker Desktop"
+    # Configure docker to run with tcp://localhost:2375 exposed
+    - ps: |
+        $config = Get-Content "C:\Users\appveyor\AppData\Roaming\Docker\settings.json" -raw | ConvertFrom-Json
+        $config.exposeDockerAPIOnTCP2375=$true
+        $config | ConvertTo-Json | Set-Content "C:\Users\appveyor\AppData\Roaming\Docker\settings.json" 
+    - ps: Start-Service "com.docker.service"
+    - cmd: '"C:\\Program Files\\Docker\\Docker\\Docker Desktop.exe"'
+    - ps: Switch-DockerLinux
+    - cmd: docker -H tcp://localhost:2375 info
+install:
+    - cmd: choco install docker-compose
+build_script:
+    - cmd: gradlew assemble
+test_script:
+    - cmd: gradlew check -i -PintegrationTestGradleVersions=6.4

--- a/src/integrationTest/examples/example-buildargs/.dockerignore
+++ b/src/integrationTest/examples/example-buildargs/.dockerignore
@@ -1,0 +1,2 @@
+.gradle/
+build/

--- a/src/integrationTest/examples/example-docker-plugin/.dockerignore
+++ b/src/integrationTest/examples/example-docker-plugin/.dockerignore
@@ -1,0 +1,2 @@
+.gradle/
+build/

--- a/src/integrationTest/reproductions/configure-registry-credentials/.dockerignore
+++ b/src/integrationTest/reproductions/configure-registry-credentials/.dockerignore
@@ -1,0 +1,2 @@
+.gradle/
+build/

--- a/src/integrationTest/reproductions/docker-plugin-without-config/.dockerignore
+++ b/src/integrationTest/reproductions/docker-plugin-without-config/.dockerignore
@@ -1,0 +1,2 @@
+.gradle/
+build/

--- a/src/integrationTest/reproductions/git-without-commits/.dockerignore
+++ b/src/integrationTest/reproductions/git-without-commits/.dockerignore
@@ -1,0 +1,2 @@
+.gradle/
+build/

--- a/src/integrationTest/reproductions/gitCommitWithQuoteTag/.dockerignore
+++ b/src/integrationTest/reproductions/gitCommitWithQuoteTag/.dockerignore
@@ -1,0 +1,2 @@
+.gradle/
+build/

--- a/src/integrationTest/reproductions/tagfailing/.dockerignore
+++ b/src/integrationTest/reproductions/tagfailing/.dockerignore
@@ -1,0 +1,2 @@
+.gradle/
+build/


### PR DESCRIPTION
This project can also be tested on Windows now with appveyor CI.

It needed some hacky edits to docker configuration files to get port 2375 exposed programmatically.
We only run tests for one Gradle version on Windows, as this is primarily used to test platform-dependent configurations. So there is no need to test all Gradle versions.

A succeeding build can be seen here: https://ci.appveyor.com/project/vierbergenlars/alfresco-docker-gradle-plugin

If this is good, we can configure appveyor properly under a xenit user.
