### PR TITLE
Convert addWar commands to smartCopy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,14 +42,9 @@ before_script:
 
 script:
   - >
-    if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
-      export SONAR_BRANCH="$TRAVIS_BRANCH";
-    else
-      export SONAR_BRANCH="$TRAVIS_PULL_REQUEST_BRANCH";
-    fi;
     GRADLE_ARGS="check -i -PintegrationTestGradleVersions=$GRADLE_INTEGRATION_TEST_VERSIONS";
     if [[ "$PUBLISH_SONAR" == "true" && "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
-      GRADLE_ARGS="${GRADLE_ARGS} sonarqube -Dsonar.projectKey=xenit-eu_alfresco-docker-gradle-plugin -Dsonar.organization=xenit-eu -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN -Dsonar.branch.name=$SONAR_BRANCH"
+      GRADLE_ARGS="${GRADLE_ARGS} sonarqube -Dsonar.projectKey=xenit-eu_alfresco-docker-gradle-plugin -Dsonar.organization=xenit-eu -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN"
     fi;
     ./gradlew $GRADLE_ARGS;
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ plugins {
     id 'org.ajoberstar.reckon' version "0.12.0"
     id 'com.github.johnrengelman.shadow' version '5.2.0' apply false
     id "org.sonarqube" version "3.0"
+    id "be.vbgn.ci-detect" version "0.3.0"
 }
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
@@ -195,6 +196,13 @@ jacocoTestReport {
 sonarqube {
     properties {
         properties["sonar.tests"] += sourceSets.integrationTest.java.srcDirs
+        if (ci.isPullRequest()) {
+            properties["sonar.pullrequest.key"] = ci.pullRequest
+            properties["sonar.pullrequest.branch"] = ci.branch
+            properties["sonar.pullrequest.base"] = ci.pullRequestTargetBranch
+        } else {
+            properties["sonar.branch.name"] = ci.reference
+        }
     }
 }
 

--- a/src/main/java/eu/xenit/gradle/docker/DockerBuildBehavior.java
+++ b/src/main/java/eu/xenit/gradle/docker/DockerBuildBehavior.java
@@ -7,6 +7,7 @@ import eu.xenit.gradle.docker.compose.DockerComposePlugin;
 import eu.xenit.gradle.docker.internal.JenkinsUtil;
 import eu.xenit.gradle.docker.internal.git.CannotConvertToUrlException;
 import eu.xenit.gradle.docker.internal.git.GitInfoProvider;
+import eu.xenit.gradle.docker.tasks.internal.ConsolidateFileCopyInstructionsAction;
 import eu.xenit.gradle.docker.tasks.internal.DockerBuildImage;
 import eu.xenit.gradle.docker.tasks.internal.DockerPushImage;
 import java.util.HashMap;
@@ -50,6 +51,9 @@ public class DockerBuildBehavior {
 
     public void apply(Project project) {
         this.execute(project);
+        project.getTasks().withType(Dockerfile.class).configureEach(dockerfile -> {
+            dockerfile.doFirst("Consolidate COPY instructions", new ConsolidateFileCopyInstructionsAction());
+        });
     }
 
     public void execute(Project project) {

--- a/src/main/java/eu/xenit/gradle/docker/DockerBuildBehavior.java
+++ b/src/main/java/eu/xenit/gradle/docker/DockerBuildBehavior.java
@@ -51,9 +51,9 @@ public class DockerBuildBehavior {
 
     public void apply(Project project) {
         this.execute(project);
-        project.getTasks().withType(Dockerfile.class).configureEach(dockerfile -> {
-            dockerfile.doFirst("Consolidate COPY instructions", new ConsolidateFileCopyInstructionsAction());
-        });
+        project.getTasks().withType(Dockerfile.class).configureEach(dockerfile -> dockerfile
+                .doFirst("Consolidate COPY instructions", new ConsolidateFileCopyInstructionsAction())
+        );
     }
 
     public void execute(Project project) {

--- a/src/main/java/eu/xenit/gradle/docker/alfresco/DockerAlfrescoPlugin.java
+++ b/src/main/java/eu/xenit/gradle/docker/alfresco/DockerAlfrescoPlugin.java
@@ -128,9 +128,8 @@ public class DockerAlfrescoPlugin implements Plugin<Project> {
         final List<WarEnrichmentTask> tasks = new ArrayList<>();
 
         tasks.add(project.getTasks()
-                .create("prefix" + warName + "Log4j", PrefixLog4JWarTask.class, prefixLog4JWarTask -> {
-                    prefixLog4JWarTask.getPrefix().set(warName.toUpperCase());
-                })
+                .create("prefix" + warName + "Log4j", PrefixLog4JWarTask.class,
+                        prefixLog4JWarTask -> prefixLog4JWarTask.getPrefix().set(warName.toUpperCase()))
         );
 
         tasks.add(project.getTasks()

--- a/src/main/java/eu/xenit/gradle/docker/alfresco/DockerAlfrescoPlugin.java
+++ b/src/main/java/eu/xenit/gradle/docker/alfresco/DockerAlfrescoPlugin.java
@@ -6,6 +6,7 @@ import eu.xenit.gradle.docker.alfresco.tasks.DockerfileWithWarsTask;
 import eu.xenit.gradle.docker.alfresco.tasks.InjectFilesInWarTask;
 import eu.xenit.gradle.docker.alfresco.tasks.InstallAmpsInWarTask;
 import eu.xenit.gradle.docker.alfresco.tasks.MergeWarsTask;
+import eu.xenit.gradle.docker.alfresco.tasks.PrefixLog4JWarTask;
 import eu.xenit.gradle.docker.alfresco.tasks.StripAlfrescoWarTask;
 import eu.xenit.gradle.docker.alfresco.tasks.WarEnrichmentTask;
 import eu.xenit.gradle.docker.alfresco.tasks.WarLabelOutputTask;
@@ -116,6 +117,7 @@ public class DockerAlfrescoPlugin implements Plugin<Project> {
                 .create("strip" + warName + "War", StripAlfrescoWarTask.class, stripAlfrescoWarTask -> {
                     stripAlfrescoWarTask.addPathToCopy(WarHelperImpl.MANIFEST_FILE);
                     stripAlfrescoWarTask.addPathToCopy("WEB-INF/classes/alfresco/module/*/module.properties");
+                    stripAlfrescoWarTask.addPathToCopy("WEB-INF/classes/log4j.properties");
                     if (warName.equals(ALFRESCO)) {
                         stripAlfrescoWarTask.addPathToCopy(WarHelperImpl.VERSION_PROPERTIES);
                     }
@@ -124,6 +126,12 @@ public class DockerAlfrescoPlugin implements Plugin<Project> {
         resolveTask.setInputWar(baseWar);
 
         final List<WarEnrichmentTask> tasks = new ArrayList<>();
+
+        tasks.add(project.getTasks()
+                .create("prefix" + warName + "Log4j", PrefixLog4JWarTask.class, prefixLog4JWarTask -> {
+                    prefixLog4JWarTask.getPrefix().set(warName.toUpperCase());
+                })
+        );
 
         tasks.add(project.getTasks()
                 .create("apply" + warName + "SM", InjectFilesInWarTask.class, injectFilesInWarTask -> {

--- a/src/main/java/eu/xenit/gradle/docker/alfresco/internal/version/AlfrescoVersion.java
+++ b/src/main/java/eu/xenit/gradle/docker/alfresco/internal/version/AlfrescoVersion.java
@@ -2,6 +2,8 @@ package eu.xenit.gradle.docker.alfresco.internal.version;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -27,8 +29,9 @@ public class AlfrescoVersion {
 
     @Nullable
     public static AlfrescoVersion fromAlfrescoWar(@Nonnull Path warPath) throws IOException {
-        Path versionPropertiesPath = warPath;
-        for(String pathComponent: VERSION_PROPERTIES_PATH) {
+        FileSystem zipFs = FileSystems.newFileSystem(warPath, null);
+        Path versionPropertiesPath = zipFs.getPath("/");
+        for (String pathComponent : VERSION_PROPERTIES_PATH) {
             versionPropertiesPath = versionPropertiesPath.resolve(pathComponent);
         }
         return fromAlfrescoVersionProperties(versionPropertiesPath);

--- a/src/main/java/eu/xenit/gradle/docker/alfresco/internal/version/AlfrescoVersion.java
+++ b/src/main/java/eu/xenit/gradle/docker/alfresco/internal/version/AlfrescoVersion.java
@@ -29,12 +29,13 @@ public class AlfrescoVersion {
 
     @Nullable
     public static AlfrescoVersion fromAlfrescoWar(@Nonnull Path warPath) throws IOException {
-        FileSystem zipFs = FileSystems.newFileSystem(warPath, null);
-        Path versionPropertiesPath = zipFs.getPath("/");
-        for (String pathComponent : VERSION_PROPERTIES_PATH) {
-            versionPropertiesPath = versionPropertiesPath.resolve(pathComponent);
+        try(FileSystem zipFs = FileSystems.newFileSystem(warPath, null)) {
+            Path versionPropertiesPath = zipFs.getPath("/");
+            for (String pathComponent : VERSION_PROPERTIES_PATH) {
+                versionPropertiesPath = versionPropertiesPath.resolve(pathComponent);
+            }
+            return fromAlfrescoVersionProperties(versionPropertiesPath);
         }
-        return fromAlfrescoVersionProperties(versionPropertiesPath);
     }
 
     @Nullable

--- a/src/main/java/eu/xenit/gradle/docker/alfresco/tasks/DockerfileWithWarsTask.java
+++ b/src/main/java/eu/xenit/gradle/docker/alfresco/tasks/DockerfileWithWarsTask.java
@@ -97,36 +97,6 @@ public class DockerfileWithWarsTask extends DockerfileWithCopyTask implements La
     }
 
     /**
-     * Adds a prefix to log4j log lines inside an extracted WAR
-     *
-     * @param destinationDir
-     * @param logName
-     */
-    private void improveLog4j(java.io.File destinationDir, String logName) {
-        Path path = destinationDir.toPath().resolve(Paths.get("WEB-INF", "classes", "log4j.properties"));
-        if (Files.exists(path)) {
-            getLogger().info("Prefixing logs for {} with [{}]", destinationDir.getName(), logName);
-            Charset charset = StandardCharsets.UTF_8;
-            try {
-                String content = new String(Files.readAllBytes(path), charset);
-                content = content.replaceAll("log4j\\.rootLogger=error,\\ Console,\\ File",
-                        "log4j\\.rootLogger=error,\\ Console");
-                //prefix the loglines with the base
-                content = content
-                        .replaceAll("log4j\\.appender\\.Console\\.layout\\.ConversionPattern=\\%d\\{ISO8601\\}",
-                                "log4j\\.appender\\.Console\\.layout\\.ConversionPattern=\\[" + logName
-                                        + "\\]\\ %d\\{ISO8601\\}");
-                Files.write(path, content.getBytes(charset));
-            } catch (IOException e) {
-                throw new IllegalStateException(e);
-            }
-        } else {
-            getLogger().info("No log4j.properties available in {}. Not changing the console appender",
-                    destinationDir.getName());
-        }
-    }
-
-    /**
      * Unzips a war file to a directory
      *
      * @param warFile
@@ -217,8 +187,6 @@ public class DockerfileWithWarsTask extends DockerfileWithCopyTask implements La
             });
 
             if (destinationDir.exists()) {
-                improveLog4j(destinationDir, name.toUpperCase());
-
                 // COPY
                 if (getRemoveExistingWar().get()) {
                     runCommand("rm -rf " + getTargetDirectory().get() + name);

--- a/src/main/java/eu/xenit/gradle/docker/alfresco/tasks/PrefixLog4JWarTask.java
+++ b/src/main/java/eu/xenit/gradle/docker/alfresco/tasks/PrefixLog4JWarTask.java
@@ -4,7 +4,6 @@ import de.schlichtherle.truezip.file.TFile;
 import de.schlichtherle.truezip.file.TFileInputStream;
 import de.schlichtherle.truezip.file.TFileOutputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -61,7 +60,7 @@ public class PrefixLog4JWarTask extends AbstractWarEnrichmentTask {
     private void prefixProperties(Properties log4jProperties) {
         if (log4jProperties.containsKey(LOG4J_ROOT_LOGGER)) {
             String rootLogger = log4jProperties.getProperty(LOG4J_ROOT_LOGGER);
-            log4jProperties.setProperty(LOG4J_ROOT_LOGGER, rootLogger.replaceAll(", File", ""));
+            log4jProperties.setProperty(LOG4J_ROOT_LOGGER, rootLogger.replace(", File", ""));
         }
         if (log4jProperties.containsKey(LOG4J_CONVERSION_PATTERN)) {
             String conversionPattern = log4jProperties.getProperty(LOG4J_CONVERSION_PATTERN);

--- a/src/main/java/eu/xenit/gradle/docker/alfresco/tasks/PrefixLog4JWarTask.java
+++ b/src/main/java/eu/xenit/gradle/docker/alfresco/tasks/PrefixLog4JWarTask.java
@@ -1,0 +1,73 @@
+package eu.xenit.gradle.docker.alfresco.tasks;
+
+import de.schlichtherle.truezip.file.TFile;
+import de.schlichtherle.truezip.file.TFileInputStream;
+import de.schlichtherle.truezip.file.TFileOutputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.util.Properties;
+import org.apache.commons.io.FileUtils;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.TaskAction;
+
+public class PrefixLog4JWarTask extends AbstractWarEnrichmentTask {
+
+    private static final String LOG4J_ROOT_LOGGER = "log4j.rootLogger";
+    private static final String LOG4J_CONVERSION_PATTERN = "log4j.appender.Console.layout.ConversionPattern";
+    private final Property<String> log4JProperties = getProject().getObjects().property(String.class)
+            .convention("/WEB-INF/classes/log4j.properties");
+
+    private final Property<String> prefix = getProject().getObjects().property(String.class);
+
+    public Property<String> getPrefix() {
+        return prefix;
+    }
+
+    public Property<String> getLog4JProperties() {
+        return log4JProperties;
+    }
+
+    @TaskAction
+    public void prefixLog4J() throws IOException {
+        File outputWar = getOutputWar().get().getAsFile();
+        FileUtils.copyFile(getInputWar().getAsFile().get(), outputWar);
+        Util.withWar(outputWar, war -> {
+            TFile propertiesFile = new TFile(war.getAbsolutePath() + getLog4JProperties().get());
+
+            if (propertiesFile.exists()) {
+                Properties log4jProperties = new Properties();
+                try (InputStream propertiesFileInput = new TFileInputStream(propertiesFile)) {
+                    log4jProperties.load(propertiesFileInput);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+
+                prefixProperties(log4jProperties);
+
+                try (OutputStream propertiesFileOutput = new TFileOutputStream(propertiesFile)) {
+                    log4jProperties.store(propertiesFileOutput, null);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+
+            }
+        });
+    }
+
+    private void prefixProperties(Properties log4jProperties) {
+        if (log4jProperties.containsKey(LOG4J_ROOT_LOGGER)) {
+            String rootLogger = log4jProperties.getProperty(LOG4J_ROOT_LOGGER);
+            log4jProperties.setProperty(LOG4J_ROOT_LOGGER, rootLogger.replaceAll(", File", ""));
+        }
+        if (log4jProperties.containsKey(LOG4J_CONVERSION_PATTERN)) {
+            String conversionPattern = log4jProperties.getProperty(LOG4J_CONVERSION_PATTERN);
+            log4jProperties.setProperty(LOG4J_CONVERSION_PATTERN, "[" + getPrefix().get() + "] " + conversionPattern);
+        }
+    }
+
+
+}

--- a/src/main/java/eu/xenit/gradle/docker/tasks/DockerfileWithCopyTask.java
+++ b/src/main/java/eu/xenit/gradle/docker/tasks/DockerfileWithCopyTask.java
@@ -1,7 +1,6 @@
 package eu.xenit.gradle.docker.tasks;
 
 import com.bmuschko.gradle.docker.tasks.image.Dockerfile;
-import java.nio.file.Path;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.Directory;
@@ -105,7 +104,7 @@ public class DockerfileWithCopyTask extends Dockerfile {
         copyFileCopySpec.into(stagingDirectory, copySpec -> {
             copySpec.from(files);
         });
-        copyFile(destinationInImage.map(d -> new CopyFile(stagingDirectory, d)));
+        copyFile(destinationInImage.map(d -> new CopyFile(stagingDirectory + "/", d + "/")));
         getInputs().files(files).withPropertyName("copyFile." + copyFileCounter);
     }
 

--- a/src/main/java/eu/xenit/gradle/docker/tasks/DockerfileWithCopyTask.java
+++ b/src/main/java/eu/xenit/gradle/docker/tasks/DockerfileWithCopyTask.java
@@ -129,10 +129,8 @@ public class DockerfileWithCopyTask extends Dockerfile {
         // FileCollections are added with smartCopy
         for(int i = 1; i <= copyFileCounter; i++) {
             java.io.File copyFile = copyFileDirectory.get().dir(Integer.toString(i)).getAsFile();
-            if(!copyFile.exists()) {
-                if(!copyFile.mkdir()) {
-                    throw new UncheckedIOException("Cannot create folder "+copyFile);
-                }
+            if(!copyFile.exists() && !copyFile.mkdir()) {
+                throw new UncheckedIOException("Cannot create folder "+copyFile);
             }
 
         }

--- a/src/main/java/eu/xenit/gradle/docker/tasks/internal/ConsolidateFileCopyInstructionsAction.java
+++ b/src/main/java/eu/xenit/gradle/docker/tasks/internal/ConsolidateFileCopyInstructionsAction.java
@@ -1,0 +1,108 @@
+package eu.xenit.gradle.docker.tasks.internal;
+
+import com.bmuschko.gradle.docker.tasks.image.Dockerfile;
+import com.bmuschko.gradle.docker.tasks.image.Dockerfile.CopyFile;
+import com.bmuschko.gradle.docker.tasks.image.Dockerfile.CopyFileInstruction;
+import com.bmuschko.gradle.docker.tasks.image.Dockerfile.Instruction;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.gradle.api.Action;
+import org.gradle.api.NonNullApi;
+import org.gradle.api.Task;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+
+@NonNullApi
+public class ConsolidateFileCopyInstructionsAction implements Action<Task> {
+
+    private static final Logger LOGGER = Logging.getLogger(ConsolidateFileCopyInstructionsAction.class);
+
+    @Override
+    public void execute(Task task) {
+        if (task instanceof Dockerfile) {
+            execute((Dockerfile) task);
+        } else {
+            throw new IllegalArgumentException("ConsolidateFileCopyAction can only be applied to Dockerfile tasks");
+        }
+    }
+
+    public void execute(Dockerfile dockerfile) {
+        List<Instruction> instructions = dockerfile.getInstructions().get();
+        List<Instruction> newInstructions = new ArrayList<>(instructions.size());
+
+        @Nullable
+        CopyFileInstruction currentCopyInstruction = null;
+
+        for (Instruction instruction : instructions) {
+            if (instruction instanceof CopyFileInstruction) {
+                LOGGER.debug("Processing copy instruction: '{}'", instruction.getText());
+                CopyFileInstruction copyFileInstruction = (CopyFileInstruction) instruction;
+                if (currentCopyInstruction == null) {
+                    LOGGER.debug("Set as current target copy instruction");
+                    currentCopyInstruction = copyFileInstruction;
+                    continue;
+                } else if (isSameTarget(copyFileInstruction, currentCopyInstruction)) {
+                    LOGGER.debug("Consolidating copy instructions: '{}' + '{}'", currentCopyInstruction.getText(),
+                            copyFileInstruction.getText());
+                    currentCopyInstruction = consolidateCopy(currentCopyInstruction, copyFileInstruction);
+                    LOGGER.debug("Consolidated to '{}'", currentCopyInstruction.getText());
+                    continue;
+                }
+            }
+            if (currentCopyInstruction != null) {
+                LOGGER.debug("Adding consolidated instruction to final instruction stream: '{}'",
+                        currentCopyInstruction.getText());
+                newInstructions.add(currentCopyInstruction);
+                currentCopyInstruction = null;
+            }
+            LOGGER.debug("Adding instruction to instruction stream: '{}'", instruction.getText());
+            newInstructions.add(instruction);
+        }
+
+        if (currentCopyInstruction != null) {
+            LOGGER.debug("Adding consolidated instruction to final instruction stream: '{}'",
+                    currentCopyInstruction.getText());
+            newInstructions.add(currentCopyInstruction);
+        }
+
+        dockerfile.getInstructions().set(newInstructions);
+    }
+
+    private static boolean isSameTarget(CopyFileInstruction a, CopyFileInstruction b) {
+        CopyFile copyFileA = a.getFile();
+        CopyFile copyFileB = b.getFile();
+        // Targets must end with / to be able to copy multiple items to it
+        if (!copyFileA.getDest().endsWith("/")) {
+            return false;
+        }
+        if (!Objects.equals(copyFileA.getStage(), copyFileB.getStage())) {
+            return false;
+        }
+        if (!Objects.equals(copyFileA.getChown(), copyFileB.getChown())) {
+            return false;
+        }
+        if (!Objects.equals(copyFileA.getDest(), copyFileB.getDest())) {
+            return false;
+        }
+        return true;
+    }
+
+    private static CopyFileInstruction consolidateCopy(CopyFileInstruction a, CopyFileInstruction b) {
+        if (!isSameTarget(a, b)) {
+            throw new IllegalArgumentException("CopyFileInstructions do not have the same destination");
+        }
+
+        CopyFile copyFile = new CopyFile(a.getFile().getSrc() + " " + b.getFile().getSrc(), a.getFile().getDest());
+        if (a.getFile().getStage() != null) {
+            copyFile.withStage(a.getFile().getStage());
+        }
+        if (a.getFile().getChown() != null) {
+            copyFile.withChown(a.getFile().getChown());
+        }
+
+        return new CopyFileInstruction(copyFile);
+    }
+
+}

--- a/src/test/java/eu/xenit/gradle/docker/alfresco/tasks/DockerfileWithWarsTaskTest.java
+++ b/src/test/java/eu/xenit/gradle/docker/alfresco/tasks/DockerfileWithWarsTaskTest.java
@@ -1,0 +1,196 @@
+package eu.xenit.gradle.docker.alfresco.tasks;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.bmuschko.gradle.docker.tasks.image.Dockerfile;
+import com.bmuschko.gradle.docker.tasks.image.Dockerfile.Instruction;
+import eu.xenit.gradle.docker.alfresco.internal.version.AlfrescoVersion;
+import eu.xenit.gradle.docker.alfresco.tasks.DockerfileWithWarsTask.ElideDuplicateVersionChecksAction;
+import eu.xenit.gradle.docker.alfresco.tasks.DockerfileWithWarsTask.RemoveNoOpInstructionsAction;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+public class DockerfileWithWarsTaskTest {
+
+    private static DockerfileWithWarsTask createDockerfile(Action<DockerfileWithWarsTask> configure) {
+        Project project = ProjectBuilder.builder().build();
+        return project.getTasks().register("createDockerFile", DockerfileWithWarsTask.class, configure).get();
+    }
+
+    private static List<String> instructionsToString(Dockerfile dockerfile) {
+        return instructionsToString(dockerfile.getInstructions().get());
+    }
+
+    private static List<String> instructionsToString(List<? extends Instruction> instructionList) {
+        return instructionList.stream()
+                .map(Instruction::getText)
+                .collect(Collectors.toList());
+    }
+
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    private File warFile;
+
+    @Before
+    public void copyWar() throws IOException {
+        warFile = temporaryFolder.newFile();
+        warFile.delete();
+        Files.copy(getClass().getResourceAsStream("/test123.war"), warFile.toPath());
+    }
+
+    @Test
+    public void requiresBaseImage() {
+        DockerfileWithWarsTask dockerfileWithWarsTask = createDockerfile(dockerfile -> {
+
+        });
+
+        expectedException.expectMessage(is(DockerfileWithWarsTask.MESSAGE_BASE_IMAGE_NOT_SET));
+        // This results in an exception when trying to resolve the FROM instruction
+        instructionsToString(dockerfileWithWarsTask);
+    }
+
+    @Test
+    public void defaultAddWarSettings() {
+        DockerfileWithWarsTask dockerfileWithWarsTask = createDockerfile(dockerfile -> {
+            dockerfile.getBaseImage().set("scratch");
+            dockerfile.addWar("abc", warFile);
+            dockerfile.addWar("abc", warFile);
+            dockerfile.addWar("def", warFile);
+        });
+
+        new RemoveNoOpInstructionsAction().execute(dockerfileWithWarsTask);
+
+        List<String> instructions = instructionsToString(dockerfileWithWarsTask);
+
+        assertEquals(Arrays.asList(
+                "FROM scratch",
+                "RUN rm -rf "+dockerfileWithWarsTask.getTargetDirectory().get()+"abc",
+                "COPY copyFile/1/ "+dockerfileWithWarsTask.getTargetDirectory().get()+"abc/",
+                "COPY copyFile/2/ "+dockerfileWithWarsTask.getTargetDirectory().get()+"abc/",
+                "RUN rm -rf "+dockerfileWithWarsTask.getTargetDirectory().get()+"def",
+                "COPY copyFile/3/ "+dockerfileWithWarsTask.getTargetDirectory().get()+"def/"
+        ), instructions);
+    }
+
+    @Test
+    public void removeNoOpInstructions() {
+        DockerfileWithWarsTask dockerfileWithWarsTask = createDockerfile(dockerfile -> {
+            dockerfile.getBaseImage().set("scratch");
+            dockerfile.getRemoveExistingWar().set(false);
+            dockerfile.addWar("abc", warFile);
+        });
+
+
+        List<String> instructionsBeforeRemove = instructionsToString(dockerfileWithWarsTask);
+
+        assertTrue("Contains a no-op RUN instruction",
+                instructionsBeforeRemove.stream().anyMatch(i -> i.startsWith("RUN true")));
+
+        new RemoveNoOpInstructionsAction().execute(dockerfileWithWarsTask);
+
+        List<String> instructionsAfterRemove = instructionsToString(dockerfileWithWarsTask);
+
+        assertFalse("Contains a no-op RUN instruction",
+                instructionsAfterRemove.stream().anyMatch(i -> i.startsWith("RUN true")));
+    }
+
+    @Test
+    public void elideDuplicateVersionCheckInstructions() throws IOException {
+
+        DockerfileWithWarsTask dockerfileWithWarsTask = createDockerfile(dockerfile -> {
+            dockerfile.getBaseImage().set("scratch");
+            dockerfile.getRemoveExistingWar().set(false);
+            dockerfile.addWar("abc", warFile);
+            dockerfile.addWar("abc", warFile);
+            dockerfile.addWar("def", warFile);
+        });
+
+        String versionCheckCommand = Objects.requireNonNull(AlfrescoVersion.fromAlfrescoWar(warFile.toPath()))
+                .getCheckCommand(dockerfileWithWarsTask.getTargetDirectory().get() + "abc");
+
+        List<String> instructionsBeforeRemove = instructionsToString(dockerfileWithWarsTask);
+
+        assertEquals(2,
+                instructionsBeforeRemove.stream().filter(i -> i.startsWith("RUN " + versionCheckCommand)).count());
+
+        new ElideDuplicateVersionChecksAction().execute(dockerfileWithWarsTask);
+
+        List<String> instructionsAfterRemove = instructionsToString(dockerfileWithWarsTask);
+        assertEquals(1,
+                instructionsAfterRemove.stream().filter(i -> i.startsWith("RUN " + versionCheckCommand)).count());
+
+        // Check that check command for other path is not elided
+        String otherVersionCheckCommand = Objects.requireNonNull(AlfrescoVersion.fromAlfrescoWar(warFile.toPath()))
+                .getCheckCommand(dockerfileWithWarsTask.getTargetDirectory().get() + "def");
+        assertEquals(1,
+                instructionsAfterRemove.stream().filter(i -> i.startsWith("RUN " + otherVersionCheckCommand)).count());
+    }
+
+    @Test
+    public void lazyResolveRemoveExistingWar() {
+        DockerfileWithWarsTask dockerfileWithWarsTask = createDockerfile(dockerfile -> {
+            dockerfile.getBaseImage().set("scratch");
+            dockerfile.addWar("abc", warFile);
+            dockerfile.addWar("abc", warFile);
+            dockerfile.addWar("def", warFile);
+            dockerfile.getRemoveExistingWar().set(false);
+        });
+
+        List<String> instructions = instructionsToString(dockerfileWithWarsTask);
+
+        assertEquals("Contains no rm -rf of abc war", 0, instructions.stream()
+                .filter(i -> i.startsWith("RUN rm -rf " + dockerfileWithWarsTask.getTargetDirectory().get() + "abc"))
+                .count());
+    }
+
+    @Test
+    public void lazyResolveTargetDirectory() {
+        DockerfileWithWarsTask dockerfileWithWarsTask = createDockerfile(dockerfile -> {
+            dockerfile.getBaseImage().set("scratch");
+            dockerfile.addWar("abc", warFile);
+            dockerfile.addWar("abc", warFile);
+            dockerfile.addWar("def", warFile);
+            dockerfile.getTargetDirectory().set("/some/other/path");
+        });
+
+        List<String> instructions = instructionsToString(dockerfileWithWarsTask);
+        assertTrue("Target directory has changed", instructions.stream().anyMatch(i -> i.contains("/some/other/path")));
+    }
+
+    @Test
+    public void lazyResolveCheckAlfrescoVersion() throws IOException {
+        DockerfileWithWarsTask dockerfileWithWarsTask = createDockerfile(dockerfile -> {
+            dockerfile.getBaseImage().set("scratch");
+            dockerfile.getRemoveExistingWar().set(false);
+            dockerfile.addWar("abc", warFile);
+            dockerfile.addWar("abc", warFile);
+            dockerfile.addWar("def", warFile);
+            dockerfile.getCheckAlfrescoVersion().set(false);
+        });
+
+        List<String> instructions = instructionsToString(dockerfileWithWarsTask);
+        String versionCheckCommand = Objects.requireNonNull(AlfrescoVersion.fromAlfrescoWar(warFile.toPath()))
+                .getCheckCommand(dockerfileWithWarsTask.getTargetDirectory().get() + "abc");
+        assertTrue("No alfresco version checks are in the instructions", instructions.stream().noneMatch(i -> i.startsWith("RUN "+versionCheckCommand)));
+    }
+}

--- a/src/test/java/eu/xenit/gradle/docker/tasks/internal/ConsolidateFileCopyInstructionsActionTest.java
+++ b/src/test/java/eu/xenit/gradle/docker/tasks/internal/ConsolidateFileCopyInstructionsActionTest.java
@@ -1,0 +1,130 @@
+package eu.xenit.gradle.docker.tasks.internal;
+
+import static org.junit.Assert.*;
+
+import com.bmuschko.gradle.docker.tasks.image.Dockerfile;
+import com.bmuschko.gradle.docker.tasks.image.Dockerfile.CopyFile;
+import com.bmuschko.gradle.docker.tasks.image.Dockerfile.Instruction;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.gradle.api.Action;
+import org.gradle.api.internal.project.DefaultProject;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.Test;
+
+public class ConsolidateFileCopyInstructionsActionTest {
+
+    private static List<Instruction> createConsolidatedInstructions(Action<Dockerfile> configure) {
+        DefaultProject project = (DefaultProject) ProjectBuilder.builder().build();
+        Dockerfile dockerfileTask = project.getTasks().register("createDockerFile", Dockerfile.class, configure).get();
+
+        new ConsolidateFileCopyInstructionsAction().execute(dockerfileTask);
+
+        return dockerfileTask.getInstructions().get();
+    }
+
+    private static List<String> instructionsToString(List<Instruction> instructionList) {
+        return instructionList.stream()
+                .map(Instruction::getText)
+                .collect(Collectors.toList());
+    }
+
+    private static List<String> createConsolidatedInstructionsString(Action<Dockerfile> configure) {
+        return instructionsToString(createConsolidatedInstructions(configure));
+    }
+
+    @Test
+    public void consolidateDirectoriesToSameDirectory() {
+        List<String> instructions = createConsolidatedInstructionsString(dockerfile -> {
+            dockerfile.copyFile("dir1/", "target/");
+            dockerfile.copyFile("dir2/", "target/");
+        });
+
+        assertEquals(Collections.singletonList("COPY dir1/ dir2/ target/"), instructions);
+    }
+
+    @Test
+    public void consolidateFilesToSameDirectory() {
+        List<String> instructions = createConsolidatedInstructionsString(dockerfile -> {
+            dockerfile.copyFile("file1", "target/");
+            dockerfile.copyFile("file2", "target/");
+        });
+
+        assertEquals(Collections.singletonList("COPY file1 file2 target/"), instructions);
+    }
+
+    @Test
+    public void consolidateDirectoriesWithStage() {
+
+        List<String> instructions = createConsolidatedInstructionsString(dockerfile -> {
+            dockerfile.copyFile(new CopyFile("dir1/", "target/").withStage("abc"));
+            dockerfile.copyFile(new CopyFile("dir2/", "target/").withStage("abc"));
+        });
+
+        assertEquals(Collections.singletonList("COPY --from=abc dir1/ dir2/ target/"), instructions);
+    }
+
+    @Test
+    public void consolidateDirectoriesWithChown() {
+
+        List<String> instructions = createConsolidatedInstructionsString(dockerfile -> {
+            dockerfile.copyFile((CopyFile) new CopyFile("dir1/", "target/").withChown("abc"));
+            dockerfile.copyFile((CopyFile) new CopyFile("dir2/", "target/").withChown("abc"));
+        });
+
+        assertEquals(Collections.singletonList("COPY --chown=abc dir1/ dir2/ target/"), instructions);
+    }
+
+    @Test
+    public void consolidateFilesToDifferentDirectory() {
+        List<String> instructions = createConsolidatedInstructionsString(dockerfile -> {
+            dockerfile.copyFile("file1", "target1/");
+            dockerfile.copyFile("file2", "target2/");
+        });
+
+        assertEquals(Arrays.asList("COPY file1 target1/", "COPY file2 target2/"), instructions);
+    }
+
+    @Test
+    public void consolidateFilesToSameFile() {
+        List<String> instructions = createConsolidatedInstructionsString(dockerfile -> {
+            dockerfile.copyFile("file1", "target");
+            dockerfile.copyFile("file2", "target");
+        });
+
+        assertEquals(Arrays.asList("COPY file1 target", "COPY file2 target"), instructions);
+    }
+
+    @Test
+    public void consolidateFilesWithDifferentChown() {
+        List<String> instructions = createConsolidatedInstructionsString(dockerfile -> {
+            dockerfile.copyFile((CopyFile) new CopyFile("file1", "target/").withChown("abc"));
+            dockerfile.copyFile((CopyFile) new CopyFile("file2", "target/").withChown("def"));
+        });
+
+        assertEquals(Arrays.asList("COPY --chown=abc file1 target/", "COPY --chown=def file2 target/"), instructions);
+    }
+
+    @Test
+    public void consolidateFilesWithDifferentStage() {
+        List<String> instructions = createConsolidatedInstructionsString(dockerfile -> {
+            dockerfile.copyFile(new CopyFile("file1", "target/").withStage("abc"));
+            dockerfile.copyFile(new CopyFile("file2", "target/").withStage("def"));
+        });
+
+        assertEquals(Arrays.asList("COPY --from=abc file1 target/", "COPY --from=def file2 target/"), instructions);
+    }
+
+    @Test
+    public void consolidateFilesWithInterleavedCommands() {
+        List<String> instructions = createConsolidatedInstructionsString(dockerfile -> {
+            dockerfile.copyFile(new CopyFile("file1", "target/"));
+            dockerfile.runCommand("true");
+            dockerfile.copyFile(new CopyFile("file2", "target/"));
+        });
+
+        assertEquals(Arrays.asList("COPY file1 target/", "RUN true", "COPY file2 target/"), instructions);
+    }
+}


### PR DESCRIPTION
Make `DockerfileWithWarsTask` a thinner wrapper around `DockerfileWithCopyTask`.

Previously, because files added with `addWar()` were only added during the main task action, all adding happened at the end of the Dockerfile.

This PR re-imagines the `addWar()` command as a special case of `smartCopy()`.
Like the other `Dockerfile` commands, the order in which `addWar()` and other instructions are called determines the order in the resulting Dockerfile.
This allows users to add custom instructions before, after and inbetween `addWar()` commands, allowing for more flexibility.

When using the configuration options exposed by `eu.xenit.docker-alfresco`, this change remains fully backwards compatible. For direct usage of `DockerfileWithWarsTask`, it remains mostly compatible.
The only potentially breaking change arises when the build relies on wars being added after all other commands, and these instructions being in an illogical order.

