### PR TITLE
Fix smartCopy when nothing has been copied at all.

### DIFF
--- a/src/main/java/eu/xenit/gradle/docker/tasks/DockerfileWithCopyTask.java
+++ b/src/main/java/eu/xenit/gradle/docker/tasks/DockerfileWithCopyTask.java
@@ -129,7 +129,7 @@ public class DockerfileWithCopyTask extends Dockerfile {
         // FileCollections are added with smartCopy
         for(int i = 1; i <= copyFileCounter; i++) {
             java.io.File copyFile = copyFileDirectory.get().dir(Integer.toString(i)).getAsFile();
-            if(!copyFile.exists() && !copyFile.mkdir()) {
+            if(!copyFile.exists() && !copyFile.mkdirs()) {
                 throw new UncheckedIOException("Cannot create folder "+copyFile);
             }
 


### PR DESCRIPTION
When the whole copyFile copySpec is empty, on older Gradle versions (<=5.5), the docker/copyFile directory is not created either, leading to the mkdir() call
failing because the parent directories do not exist.