### PR TITLE
Add overload methods for `DockerAutotagExtension#legacyTags`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ stages:
 
 env:
   - GRADLE_INTEGRATION_TEST_VERSIONS=5.3,5.6 PUBLISH_SONAR=true
-  - GRADLE_INTEGRATION_TEST_VERSIONS=6.0,6.6
+  - GRADLE_INTEGRATION_TEST_VERSIONS=6.0,6.7
 
 before_script:
   - 'bash -c "docker pull alfresco/alfresco-content-repository-community:6.0.7-ga& docker pull tomcat:7-jre8& docker pull hello-world& docker pull alpine:edge&"'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+ * [#173](https://github.com/xenit-eu/alfresco-docker-gradle-plugin/issues/173) - `autotag.legacyTags()` NPE when no arguments provided
+
 ## Version 5.1.0 - 2020-10-20
 
 ### Added

--- a/src/integrationTest/java/eu/xenit/gradle/testrunner/AbstractIntegrationTest.java
+++ b/src/integrationTest/java/eu/xenit/gradle/testrunner/AbstractIntegrationTest.java
@@ -44,6 +44,7 @@ public abstract class AbstractIntegrationTest {
             });
         }
         return Arrays.asList(new Object[][]{
+                {"6.7"},
                 {"6.6.1"},
                 {"6.5.1"},
                 {"6.4.1"},

--- a/src/integrationTest/java/eu/xenit/gradle/testrunner/Reproductions.java
+++ b/src/integrationTest/java/eu/xenit/gradle/testrunner/Reproductions.java
@@ -152,4 +152,14 @@ public class Reproductions extends AbstractIntegrationTest {
     public void testIssue133Label() throws IOException {
         testProjectFolder(REPRODUCTIONS.resolve("issue-133-label"), ":buildDockerImage", true);
     }
+
+    @Test
+    public void testIssue173Empty() throws IOException {
+        testProjectFolder(REPRODUCTIONS.resolve("issue-173-empty"), ":buildDockerImage");
+    }
+
+    @Test
+    public void testIssue173Array() throws IOException {
+        testProjectFolder(REPRODUCTIONS.resolve("issue-173-array"), ":buildDockerImage");
+    }
 }

--- a/src/integrationTest/reproductions/issue-173-array/build.gradle
+++ b/src/integrationTest/reproductions/issue-173-array/build.gradle
@@ -1,0 +1,13 @@
+plugins {
+    id 'eu.xenit.docker'
+}
+
+createDockerFile {
+    from("alpine:edge")
+}
+
+dockerBuild {
+    repositories = ['issue-173']
+    tags = autotag.legacyTags(["tag1", "tag2"])
+}
+

--- a/src/integrationTest/reproductions/issue-173-empty/build.gradle
+++ b/src/integrationTest/reproductions/issue-173-empty/build.gradle
@@ -1,0 +1,13 @@
+plugins {
+    id 'eu.xenit.docker'
+}
+
+createDockerFile {
+    from("alpine:edge")
+}
+
+dockerBuild {
+    repositories = ['issue-173']
+    tags = autotag.legacyTags()
+}
+

--- a/src/main/java/eu/xenit/gradle/docker/autotag/DockerAutotagExtension.java
+++ b/src/main/java/eu/xenit/gradle/docker/autotag/DockerAutotagExtension.java
@@ -2,9 +2,20 @@ package eu.xenit.gradle.docker.autotag;
 
 import eu.xenit.gradle.docker.autotag.transformer.DockerSafeTagTransformer;
 import eu.xenit.gradle.docker.autotag.transformer.LegacyTagTransformer;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 public class DockerAutotagExtension {
+
+    public Set<String> legacyTags() {
+        return legacyTags(Collections.emptySet());
+    }
+
+    public Set<String> legacyTags(List<String> tags) {
+        return legacyTags(new HashSet<>(tags));
+    }
 
     public Set<String> legacyTags(Set<String> tags) {
         return new DockerSafeTagTransformer(LegacyTagTransformer.getInstance()).transform(tags);


### PR DESCRIPTION
The `autotag.legacyTags` function only accepted a `Set<String>` as argument.

`Set<String>` is a bit annoying to construct in Gradle, so accept `List<String>` as well so array-notation in Groovy works as well.

We can also offer a no-arguments function as a shortcut, so `autotag.legacyTags()` can be used directly instead of `autotag.legacyTags([])`.

Fixes #173 