### PR TITLE
Remove empty commands before doing COPY consolidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
  * [#173](https://github.com/xenit-eu/alfresco-docker-gradle-plugin/issues/173) - `autotag.legacyTags()` NPE when no arguments provided
+ * [#175](https://github.com/xenit-eu/alfresco-docker-gradle-plugin/pull/175) - Remove empty commands before doing COPY consolidation
 
 ## Version 5.1.0 - 2020-10-20
 

--- a/src/integrationTest/java/eu/xenit/gradle/testrunner/Reproductions.java
+++ b/src/integrationTest/java/eu/xenit/gradle/testrunner/Reproductions.java
@@ -162,4 +162,9 @@ public class Reproductions extends AbstractIntegrationTest {
     public void testIssue173Array() throws IOException {
         testProjectFolder(REPRODUCTIONS.resolve("issue-173-array"), ":buildDockerImage");
     }
+
+    @Test
+    public void testRemoveEmptyCommands() throws IOException {
+        testProjectFolder(REPRODUCTIONS.resolve("remove-empty-commands"), ":createDockerFile");
+    }
 }

--- a/src/integrationTest/reproductions/remove-empty-commands/build.gradle
+++ b/src/integrationTest/reproductions/remove-empty-commands/build.gradle
@@ -1,0 +1,26 @@
+plugins {
+    id 'eu.xenit.docker-alfresco'
+}
+import java.util.stream.Collectors
+
+createDockerFile {
+    removeExistingWar = false
+    doLast {
+        def textInstructions = instructions.get().stream()
+                .map({ i -> i.text })
+                .collect(Collectors.toList())
+
+        assert textInstructions.equals([
+                'FROM tomcat:7-jre8',
+                'COPY copyFile/1/ copyFile/2/ copyFile/3/ copyFile/4/ copyFile/5/ copyFile/6/ /usr/local/tomcat/webapps/alfresco/',
+                'COPY copyFile/7/ copyFile/8/ copyFile/9/ copyFile/10/ copyFile/11/ /usr/local/tomcat/webapps/share/'
+        ])
+    }
+}
+
+dockerBuild {
+    alfresco {
+        baseImage = "tomcat:7-jre8"
+        leanImage = true
+    }
+}

--- a/src/main/java/eu/xenit/gradle/docker/alfresco/tasks/extension/internal/DockerfileWithWarsExtensionImpl.java
+++ b/src/main/java/eu/xenit/gradle/docker/alfresco/tasks/extension/internal/DockerfileWithWarsExtensionImpl.java
@@ -244,6 +244,7 @@ public class DockerfileWithWarsExtensionImpl implements DockerfileWithWarsExtens
         public void execute(Dockerfile dockerfile) {
             List<Instruction> instructions = dockerfile.getInstructions().get()
                     .stream()
+                    .filter(instruction -> instruction.getText() != null)
                     .filter(instruction -> !(instruction instanceof RunCommandInstruction && Objects
                             .equals(instruction.getText(), instruction.getKeyword() + " " + COMMAND_NO_OP)))
                     .collect(Collectors.toList());

--- a/src/main/java/eu/xenit/gradle/docker/tasks/internal/ConsolidateFileCopyInstructionsAction.java
+++ b/src/main/java/eu/xenit/gradle/docker/tasks/internal/ConsolidateFileCopyInstructionsAction.java
@@ -34,20 +34,24 @@ public class ConsolidateFileCopyInstructionsAction implements Action<Task> {
 
         @Nullable
         CopyFileInstruction currentCopyInstruction = null;
+        int instructionIndex = 0;
+        while (instructionIndex < instructions.size()) {
+            Instruction instruction = instructions.get(instructionIndex);
 
-        for (Instruction instruction : instructions) {
             if (instruction instanceof CopyFileInstruction) {
                 LOGGER.debug("Processing copy instruction: '{}'", instruction.getText());
                 CopyFileInstruction copyFileInstruction = (CopyFileInstruction) instruction;
                 if (currentCopyInstruction == null) {
                     LOGGER.debug("Set as current target copy instruction");
                     currentCopyInstruction = copyFileInstruction;
+                    instructionIndex++;
                     continue;
                 } else if (isSameTarget(copyFileInstruction, currentCopyInstruction)) {
                     LOGGER.debug("Consolidating copy instructions: '{}' + '{}'", currentCopyInstruction.getText(),
                             copyFileInstruction.getText());
                     currentCopyInstruction = consolidateCopy(currentCopyInstruction, copyFileInstruction);
                     LOGGER.debug("Consolidated to '{}'", currentCopyInstruction.getText());
+                    instructionIndex++;
                     continue;
                 }
             }
@@ -56,9 +60,12 @@ public class ConsolidateFileCopyInstructionsAction implements Action<Task> {
                         currentCopyInstruction.getText());
                 newInstructions.add(currentCopyInstruction);
                 currentCopyInstruction = null;
+                // Not bumping instructionIndex, so the new instruction is reprocessed
+                continue;
             }
             LOGGER.debug("Adding instruction to instruction stream: '{}'", instruction.getText());
             newInstructions.add(instruction);
+            instructionIndex++;
         }
 
         if (currentCopyInstruction != null) {

--- a/src/test/java/eu/xenit/gradle/docker/tasks/internal/ConsolidateFileCopyInstructionsActionTest.java
+++ b/src/test/java/eu/xenit/gradle/docker/tasks/internal/ConsolidateFileCopyInstructionsActionTest.java
@@ -127,4 +127,16 @@ public class ConsolidateFileCopyInstructionsActionTest {
 
         assertEquals(Arrays.asList("COPY file1 target/", "RUN true", "COPY file2 target/"), instructions);
     }
+
+    @Test
+    public void consolidateFilesWithDifferentTargets() {
+        List<String> instructions = createConsolidatedInstructionsString(dockerfile -> {
+            dockerfile.copyFile("dir1/", "target/");
+            dockerfile.copyFile("dir2/", "target/");
+            dockerfile.copyFile("dir3/", "target2/");
+            dockerfile.copyFile("dir4/", "target2/");
+        });
+
+        assertEquals(Arrays.asList("COPY dir1/ dir2/ target/", "COPY dir3/ dir4/ target2/"), instructions);
+    }
 }


### PR DESCRIPTION
In some cases, commands with `null` text may be inserted into the instructions stream.

These are removed during the creation of the Dockerfile itself, but are still present when doing COPY consolidation, resulting in a suboptimal consolidation.

Additionally, when 2 series of COPY commands with different targets follow each other, the first entry of the second series was not consolidated properly.