### PR TITLE
Fix deprecation warnings shown incorrectly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@
 
 ### Added
 
- *  [#170](https://github.com/xenit-eu/alfresco-docker-gradle-plugin/issues/170) - dockerCompose.fromProject() with user-configured environment variable
+* [#170](https://github.com/xenit-eu/alfresco-docker-gradle-plugin/issues/170) - dockerCompose.fromProject() with
+  user-configured environment variable
+
+### Fixed
+
+* [#187](https://github.com/xenit-eu/alfresco-docker-gradle-plugin/pull/187) - Fix deprecation warnings shown
+  incorrectly
 
 ## Version 5.1.1 - 2020-11-24
 

--- a/src/main/java/eu/xenit/gradle/docker/DockerBuildExtension.java
+++ b/src/main/java/eu/xenit/gradle/docker/DockerBuildExtension.java
@@ -45,15 +45,15 @@ public class DockerBuildExtension {
             }
         }));
         tags = objectFactory.listProperty(String.class);
+        automaticTags = objectFactory.property(Boolean.class).convention(false);
         dockerExtension.getTags().addAll(tags.flatMap(
-                t -> getAutomaticTags().map(automaticTags ->
-                        automaticTags ? dockerExtension.getExtensions().getByType(DockerAutotagExtension.class)
+                t -> automaticTags.map(at ->
+                        at ? dockerExtension.getExtensions().getByType(DockerAutotagExtension.class)
                                 .legacyTags(new HashSet<>(t)) : new HashSet<>(t)
                 )
         ));
         pull = objectFactory.property(Boolean.class).convention(true);
         noCache = objectFactory.property(Boolean.class).convention(false);
-        automaticTags = objectFactory.property(Boolean.class).convention(false);
         remove = objectFactory.property(Boolean.class).convention(true);
     }
 

--- a/src/main/java/eu/xenit/gradle/docker/DockerFileExtension.java
+++ b/src/main/java/eu/xenit/gradle/docker/DockerFileExtension.java
@@ -19,7 +19,7 @@ public class DockerFileExtension {
     @Inject
     public DockerFileExtension(ObjectFactory objectFactory, DockerExtension dockerExtension) {
         dockerFile = dockerExtension.getDockerFile();
-        dockerBuild = objectFactory.newInstance(DockerBuildExtension.class, dockerExtension, "dockerFile");
+        dockerBuild = objectFactory.newInstance(DockerBuildExtension.class, dockerExtension, "dockerFile.");
     }
 
     public RegularFileProperty getDockerFile() {

--- a/src/main/java/eu/xenit/gradle/docker/alfresco/DockerAlfrescoExtension.java
+++ b/src/main/java/eu/xenit/gradle/docker/alfresco/DockerAlfrescoExtension.java
@@ -29,7 +29,7 @@ public class DockerAlfrescoExtension {
         AlfrescoDockerExtension alfrescoDockerExtension = dockerExtension.getExtensions().findByType(AlfrescoDockerExtension.class);
         baseImage = alfrescoDockerExtension.getBaseImage();
         leanImage = alfrescoDockerExtension.getLeanImage();
-        dockerBuild = objectFactory.newInstance(DockerBuildExtension.class, dockerExtension, "dockerAlfresco");
+        dockerBuild = objectFactory.newInstance(DockerBuildExtension.class, dockerExtension, "dockerAlfresco.");
     }
 
     public Property<String> getBaseImage() {

--- a/src/main/java/eu/xenit/gradle/docker/core/DockerPlugin.java
+++ b/src/main/java/eu/xenit/gradle/docker/core/DockerPlugin.java
@@ -3,6 +3,7 @@ package eu.xenit.gradle.docker.core;
 import com.bmuschko.gradle.docker.tasks.image.DockerPushImage;
 import com.bmuschko.gradle.docker.tasks.image.Dockerfile;
 import eu.xenit.gradle.docker.DockerLegacyPlugin;
+import eu.xenit.gradle.docker.internal.Deprecation;
 import eu.xenit.gradle.docker.label.DockerLabelExtension;
 import eu.xenit.gradle.docker.label.DockerLabelPlugin;
 import eu.xenit.gradle.docker.autotag.DockerAutotagPlugin;
@@ -44,7 +45,9 @@ public class DockerPlugin implements Plugin<Project> {
         project.getPluginManager().apply(DockerAutotagPlugin.class);
         project.getPluginManager().apply(DockerLabelPlugin.class);
 
-        project.getPluginManager().apply(DockerLegacyPlugin.class);
+        Deprecation.whileDisabled(() -> {
+            project.getPluginManager().apply(DockerLegacyPlugin.class);
+        });
 
         // Configure labeling from git
         dockerExtension.getExtensions().getByType(DockerLabelExtension.class).fromGit();

--- a/src/main/java/eu/xenit/gradle/docker/internal/Deprecation.java
+++ b/src/main/java/eu/xenit/gradle/docker/internal/Deprecation.java
@@ -93,12 +93,12 @@ public final class Deprecation {
         try {
             throw new Warning(message);
         } catch (Warning warning) {
-            if (warningMode.name().equals("Fail")) {
-                throw warning;
-            }
             StackTraceElement[] stackTraceElements = warning.getStackTrace();
             warning.setStackTrace(
                     Arrays.copyOfRange(stackTraceElements, stripTraces + 1, stackTraceElements.length - stripTraces));
+            if (warningMode.name().equals("Fail")) {
+                throw warning;
+            }
             if (warningMode == WarningMode.All) {
                 printWarning(warning);
             }

--- a/src/main/java/eu/xenit/gradle/docker/internal/Deprecation.java
+++ b/src/main/java/eu/xenit/gradle/docker/internal/Deprecation.java
@@ -3,6 +3,7 @@ package eu.xenit.gradle.docker.internal;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import org.gradle.StartParameter;
 import org.gradle.api.logging.Logger;
@@ -22,7 +23,8 @@ public final class Deprecation {
     private static WarningMode warningMode = WarningMode.Summary;
     private static ShowStacktrace printStacktrace = ShowStacktrace.INTERNAL_EXCEPTIONS;
     private static List<Warning> warnings = new LinkedList<>();
-    private static ThreadLocal<Boolean> suppressDeprecations = ThreadLocal.withInitial(() -> false);
+    private static ThreadLocal<AtomicInteger> suppressDeprecations = ThreadLocal
+            .withInitial(() -> new AtomicInteger(0));
 
     static Logger LOGGER = Logging.getLogger(Deprecation.class);
 
@@ -37,11 +39,13 @@ public final class Deprecation {
     }
 
     public static <T> T whileDisabled(Supplier<T> supplier) {
-        suppressDeprecations.set(true);
+        suppressDeprecations.get().incrementAndGet();
         try {
             return supplier.get();
         } finally {
-            suppressDeprecations.remove();
+            if (suppressDeprecations.get().decrementAndGet() == 0) {
+                suppressDeprecations.remove();
+            }
         }
     }
 
@@ -86,7 +90,7 @@ public final class Deprecation {
     }
 
     private static void createWarning(String message, int stripTraces) {
-        if(suppressDeprecations.get()) {
+        if (suppressDeprecations.get().get() != 0) {
             // Do not create a warning when deprecation warnings are suppressed
             return;
         }


### PR DESCRIPTION
When upgrading an other project, I noticed that deprecation warnings were logged even when no user code was touching the deprecated parts anymore.

It turns out that some internal code in the same class was using the deprecated functions, which triggered the warnings.
These warnings are not useful and might send the developer chasing after problems that aren't there.

Replacing the method calls with the properties directly fixes this issue.

