### PR TITLE
Remove all dependencies to the jcenter repository from integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           java-version: 11
       - name: Pull docker images
-        run: 'bash -c "docker pull alfresco/alfresco-content-repository-community:6.0.7-ga& docker pull tomcat:7-jre8& docker pull hello-world& docker pull alpine:edge&"'
+        run: 'parallel docker pull -- alfresco/alfresco-content-repository-community:6.0.7-ga tomcat:7-jre8 hello-world alpine:edge'
       - name: Check
         run: ./gradlew check -PintegrationTestGradleVersions=$TEST_GRADLE_VERSION
       - name: Upload reports
@@ -53,6 +53,8 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 11
+      - name: Pull docker images
+        run: 'parallel docker pull -- alfresco/alfresco-content-repository-community:6.0.7-ga tomcat:7-jre8 hello-world alpine:edge'
       - name: Check
         run: ./gradlew check -PintegrationTestGradleVersions=${{ matrix.gradle-versions }}
       - name: Upload reports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     name: "build"
     runs-on: ubuntu-latest
     env:
-        TEST_GRADLE_VERSION: 6.7
+      TEST_GRADLE_VERSION: 6.7
     steps:
       - uses: actions/checkout@v2
         with:
@@ -21,6 +21,12 @@ jobs:
         run: 'bash -c "docker pull alfresco/alfresco-content-repository-community:6.0.7-ga& docker pull tomcat:7-jre8& docker pull hello-world& docker pull alpine:edge&"'
       - name: Check
         run: ./gradlew check -PintegrationTestGradleVersions=$TEST_GRADLE_VERSION
+      - name: Upload reports
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: reports-build
+          path: build/reports
       - name: Upload analysis to sonarcloud
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -36,10 +42,10 @@ jobs:
     name: "integration-test (gradle-versions=${{ matrix.gradle-versions}})"
     runs-on: ubuntu-latest
     strategy:
-        matrix:
-            gradle-versions:
-                - 5.3,5.6
-                - 6.0,6.6
+      matrix:
+        gradle-versions:
+          - 5.3,5.6
+          - 6.0,6.6
     steps:
       - uses: actions/checkout@v2
         with:
@@ -49,3 +55,9 @@ jobs:
           java-version: 11
       - name: Check
         run: ./gradlew check -PintegrationTestGradleVersions=${{ matrix.gradle-versions }}
+      - name: Upload reports
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: reports-integration-test-${{ matrix.gradle-versions }}
+          path: build/reports

--- a/src/integrationTest/examples/lean-example/build.gradle
+++ b/src/integrationTest/examples/lean-example/build.gradle
@@ -7,7 +7,6 @@ repositories {
     maven {
         url "https://artifacts.alfresco.com/nexus/content/groups/public/"
     }
-    jcenter()
 }
 
 dependencies {

--- a/src/integrationTest/examples/publish-war/build.gradle
+++ b/src/integrationTest/examples/publish-war/build.gradle
@@ -8,7 +8,6 @@ version "1.0.0"
 
 repositories {
     mavenCentral()
-    jcenter()
     maven {
         url "https://artifacts.alfresco.com/nexus/content/groups/public/"
     }

--- a/src/integrationTest/reproductions/alfrescoDE-double-task/build.gradle
+++ b/src/integrationTest/reproductions/alfrescoDE-double-task/build.gradle
@@ -4,7 +4,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    jcenter()
     maven {
         url "https://artifacts.alfresco.com/nexus/content/groups/public/"
     }

--- a/src/integrationTest/reproductions/applyamps-subproject/build.gradle
+++ b/src/integrationTest/reproductions/applyamps-subproject/build.gradle
@@ -4,7 +4,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    jcenter()
     maven {
         url "https://artifacts.alfresco.com/nexus/content/groups/public/"
     }

--- a/src/integrationTest/reproductions/applyamps-subproject/subproject/build.gradle
+++ b/src/integrationTest/reproductions/applyamps-subproject/subproject/build.gradle
@@ -1,10 +1,13 @@
-apply plugin: "java"
+plugins {
+    id "java"
+}
+
 configurations {
     amps
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
     maven {
         url "https://artifacts.alfresco.com/nexus/content/groups/public/"
     }

--- a/src/integrationTest/reproductions/different-version-properties-between-war-and-image-should-fail/build.gradle
+++ b/src/integrationTest/reproductions/different-version-properties-between-war-and-image-should-fail/build.gradle
@@ -4,7 +4,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    jcenter()
     maven {
         url "https://artifacts.alfresco.com/nexus/content/groups/public/"
     }

--- a/src/integrationTest/reproductions/docker-plugin-without-config/build.gradle
+++ b/src/integrationTest/reproductions/docker-plugin-without-config/build.gradle
@@ -3,5 +3,4 @@ plugins {
 }
 repositories {
     mavenCentral()
-    jcenter()
 }

--- a/src/integrationTest/reproductions/git-without-commits/build.gradle
+++ b/src/integrationTest/reproductions/git-without-commits/build.gradle
@@ -2,10 +2,6 @@ plugins {
     id 'eu.xenit.docker'
 }
 
-repositories {
-    jcenter()
-}
-
 dockerFile {
     dockerFile = file('Dockerfile')
     dockerBuild {

--- a/src/integrationTest/reproductions/gitCommitWithQuoteTag/build.gradle
+++ b/src/integrationTest/reproductions/gitCommitWithQuoteTag/build.gradle
@@ -2,10 +2,6 @@ plugins {
     id 'eu.xenit.docker'
 }
 
-repositories {
-    jcenter()
-}
-
 dockerFile {
     dockerFile = file('Dockerfile')
     dockerBuild {

--- a/src/integrationTest/reproductions/issue-107/build.gradle
+++ b/src/integrationTest/reproductions/issue-107/build.gradle
@@ -4,7 +4,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    jcenter()
     maven {
         url "https://artifacts.alfresco.com/nexus/content/groups/public/"
     }

--- a/src/integrationTest/reproductions/issue-114/build.gradle
+++ b/src/integrationTest/reproductions/issue-114/build.gradle
@@ -4,7 +4,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    jcenter()
     maven {
         url "https://artifacts.alfresco.com/nexus/content/groups/public/"
     }

--- a/src/integrationTest/reproductions/issue-133-extension/build.gradle
+++ b/src/integrationTest/reproductions/issue-133-extension/build.gradle
@@ -4,7 +4,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    jcenter()
     maven {
         url "https://artifacts.alfresco.com/nexus/content/groups/public/"
     }

--- a/src/integrationTest/reproductions/issue-133-label/build.gradle
+++ b/src/integrationTest/reproductions/issue-133-label/build.gradle
@@ -4,7 +4,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    jcenter()
     maven {
         url "https://artifacts.alfresco.com/nexus/content/groups/public/"
     }

--- a/src/integrationTest/reproductions/issue-97/build.gradle
+++ b/src/integrationTest/reproductions/issue-97/build.gradle
@@ -4,7 +4,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    jcenter()
     maven {
         url "https://artifacts.alfresco.com/nexus/content/groups/public/"
     }

--- a/src/integrationTest/reproductions/issue-98/build.gradle
+++ b/src/integrationTest/reproductions/issue-98/build.gradle
@@ -4,7 +4,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    jcenter()
     maven {
         url "https://artifacts.alfresco.com/nexus/content/groups/public/"
     }

--- a/src/integrationTest/reproductions/modifyDockerfile/build.gradle
+++ b/src/integrationTest/reproductions/modifyDockerfile/build.gradle
@@ -1,14 +1,8 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-}
 plugins {
     id 'eu.xenit.docker-alfresco'
 }
 repositories {
     mavenCentral()
-    jcenter()
     maven {
         url "https://artifacts.alfresco.com/nexus/content/groups/public/"
     }

--- a/src/integrationTest/reproductions/same-version-properties-between-war-and-image-should-succeed/build.gradle
+++ b/src/integrationTest/reproductions/same-version-properties-between-war-and-image-should-succeed/build.gradle
@@ -4,7 +4,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    jcenter()
     maven {
         url "https://artifacts.alfresco.com/nexus/content/groups/public/"
     }

--- a/src/integrationTest/reproductions/tagfailing/build.gradle
+++ b/src/integrationTest/reproductions/tagfailing/build.gradle
@@ -2,10 +2,6 @@ plugins {
     id 'eu.xenit.docker'
 }
 
-repositories {
-    jcenter()
-}
-
 dockerFile {
     dockerFile = file('Dockerfile')
     dockerBuild {


### PR DESCRIPTION
Jcenter is going away, and we don't need the dependency as all required artifacts are in maven central or alfresco public.

https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/