### PR TITLE
Throw a MissingMethodException when nonexisting variants of DockerComposeConvention get called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+* [#191](https://github.com/xenit-eu/alfresco-docker-gradle-plugin/issues/191) - dockerCompose fromBuildImage/fromProject silently fail when wrong argument type is provided
+
 ## Version 5.2.0 - 2021-01-22
 
 ### Added

--- a/src/integrationTest/java/eu/xenit/gradle/testrunner/Reproductions.java
+++ b/src/integrationTest/java/eu/xenit/gradle/testrunner/Reproductions.java
@@ -172,4 +172,9 @@ public class Reproductions extends AbstractIntegrationTest {
     public void testIssue176Mitigation() throws IOException {
         testProjectFolder(REPRODUCTIONS.resolve("issue-176-mitigation"), ":createDockerFile");
     }
+
+    @Test
+    public void testIssue191() throws IOException {
+        getGradleRunner(REPRODUCTIONS.resolve("issue-191"), ":check").buildAndFail();
+    }
 }

--- a/src/integrationTest/reproductions/issue-191/build.gradle
+++ b/src/integrationTest/reproductions/issue-191/build.gradle
@@ -1,0 +1,14 @@
+plugins {
+    id "base"
+    id "eu.xenit.docker"
+    id "eu.xenit.docker-compose"
+}
+
+dockerCompose {
+    fromBuildImage(project)
+    isRequiredBy(check)
+}
+
+createDockerFile {
+    from("alpine:edge")
+}

--- a/src/integrationTest/reproductions/issue-191/docker-compose.yml
+++ b/src/integrationTest/reproductions/issue-191/docker-compose.yml
@@ -1,0 +1,5 @@
+version: '2'
+
+services:
+  alpine:
+    image: ${DOCKER_IMAGE}

--- a/src/main/java/eu/xenit/gradle/docker/compose/DockerComposeExtensionOverride.java
+++ b/src/main/java/eu/xenit/gradle/docker/compose/DockerComposeExtensionOverride.java
@@ -3,6 +3,7 @@ package eu.xenit.gradle.docker.compose;
 import com.avast.gradle.dockercompose.ComposeExtension;
 import com.avast.gradle.dockercompose.ComposeSettings;
 import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage;
+import groovy.lang.MissingMethodException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import org.gradle.api.Project;
@@ -15,6 +16,17 @@ class DockerComposeExtensionOverride extends ComposeExtension implements DockerC
     public DockerComposeExtensionOverride(Project project) {
         super(project);
         dockerComposeConvention = new ReplayableComposeConventionImpl(new DockerComposeConventionImpl(this));
+    }
+
+    @Override
+    public Object methodMissing(String name, Object args) {
+        switch (name) {
+            case "fromProject":
+            case "fromBuildImage":
+                throw new MissingMethodException(name, getClass(), (Object[]) args);
+            default:
+                return super.methodMissing(name, args);
+        }
     }
 
     @Override


### PR DESCRIPTION
By default, the methodMissing() implementation of ComposeExtension just creates a new nested ComposeSettings object.
This is not desired for the fromProject() and fromBuildImage() methods, as these are supposed to do some actual work.
If these methods get called with invalid parameters, they should throw an exception instead of falling back to creating a new ComposeSettings object which the user will never expect.

Fixes #191