### PR TITLE
Annotate input properties on PrefixLog4JWarTask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 * [#191](https://github.com/xenit-eu/alfresco-docker-gradle-plugin/issues/191) - dockerCompose fromBuildImage/fromProject silently fail when wrong argument type is provided
+* [#192](https://github.com/xenit-eu/alfresco-docker-gradle-plugin/issues/192) - Deprecated non-annotated properties in prefixXXXLog4j tasks
 
 ## Version 5.2.0 - 2021-01-22
 

--- a/src/main/java/eu/xenit/gradle/docker/alfresco/tasks/PrefixLog4JWarTask.java
+++ b/src/main/java/eu/xenit/gradle/docker/alfresco/tasks/PrefixLog4JWarTask.java
@@ -11,6 +11,7 @@ import java.io.UncheckedIOException;
 import java.util.Properties;
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
 
 public class PrefixLog4JWarTask extends AbstractWarEnrichmentTask {
@@ -22,10 +23,12 @@ public class PrefixLog4JWarTask extends AbstractWarEnrichmentTask {
 
     private final Property<String> prefix = getProject().getObjects().property(String.class);
 
+    @Input
     public Property<String> getPrefix() {
         return prefix;
     }
 
+    @Input
     public Property<String> getLog4JProperties() {
         return log4JProperties;
     }


### PR DESCRIPTION
Non-annotated properties are deprecated starting from Gradle 7, which will be released soon.

Also include a non-required check that fails when using deprecated functionality, so we can catch cases like this earlier.