### PR TITLE
Disable sonarqube without SONAR_TOKEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           name: reports-build
           path: build/reports
       - name: Upload analysis to sonarcloud
+        if: "${{ env.SONAR_TOKEN != '' }}"
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Without a SONAR_TOKEN present, it is not possible to execute the sonarqube task to submit to sonarcloud. The task will fail, failing the build.