### PR TITLE
Revert "Merge pull request #208"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id "jacoco"
     id "com.gradle.plugin-publish" version "0.14.0"
     id 'org.ajoberstar.reckon' version "0.13.0"
-    id 'com.github.johnrengelman.shadow' version '7.0.0' apply false
+    id 'com.github.johnrengelman.shadow' version '6.1.0' apply false
     id "org.sonarqube" version "3.2.0"
     id "be.vbgn.ci-detect" version "0.5.0"
 }


### PR DESCRIPTION
shadow 7.0.0 requires Gradle 7.0 to run builds.
We are currently still on Gradle 6.7 for the plugin build.

This reverts commit 98e097364177282c5e396435d8aaf28de598ad39, reversing
changes made to a69db09611d60a7010a60ff85472404d3d2ca787.

Reverts PR #208 