### PR TITLE
Bump gradle-docker-compose-plugin from 0.14.3 to 0.14.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,7 @@ dependencies {
     }
 
     implementation 'com.bmuschko:gradle-docker-plugin:6.7.0'
-    implementation 'com.avast.gradle:gradle-docker-compose-plugin:0.14.3'
+    implementation 'com.avast.gradle:gradle-docker-compose-plugin:0.14.8'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation 'org.hamcrest:hamcrest-core:2.2'
     testImplementation gradleTestKit()


### PR DESCRIPTION
0.14.8 is the last version that is fully backwards compatible, later versions have upgraded to `Property<>`