### PR TITLE
Add reproduction for overwriting files in a war with an AMP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#201](https://github.com/xenit-eu/alfresco-docker-gradle-plugin/issues/201) - Make it possible to disable rewriting log4j.properties
 
+### Fixed
+
+* [#229](https://github.com/xenit-eu/alfresco-docker-gradle-plugin/issues/229) - Overwriting files in WAR with AMP broken since v5.3.0
+
 ## Version 5.3.0 - 2021-04-21
 
 **This release drops support for Gradle versions before 5.6**

--- a/src/integrationTest/java/eu/xenit/gradle/testrunner/Reproductions.java
+++ b/src/integrationTest/java/eu/xenit/gradle/testrunner/Reproductions.java
@@ -177,4 +177,9 @@ public class Reproductions extends AbstractIntegrationTest {
     public void testIssue191() throws IOException {
         getGradleRunner(REPRODUCTIONS.resolve("issue-191"), ":check").buildAndFail();
     }
+
+    @Test
+    public void testIssue229() throws IOException {
+        testProjectFolder(REPRODUCTIONS.resolve("issue-229"), ":integrationTest");
+    }
 }

--- a/src/integrationTest/reproductions/issue-229/build.gradle
+++ b/src/integrationTest/reproductions/issue-229/build.gradle
@@ -1,0 +1,37 @@
+plugins {
+    id "base"
+    id "eu.xenit.docker-alfresco"
+    id "eu.xenit.alfresco" version "1.1.0"
+}
+
+repositories {
+    mavenCentral()
+    alfrescoPublic()
+}
+
+dependencies {
+    baseAlfrescoWar "org.alfresco:content-services-community:6.1.2-ga@war"
+    alfrescoAmp 'eu.xenit.alfresco:alfresco-hotfix-MNT-20557:1.0.2@amp'
+}
+
+task integrationTest {
+    dependsOn(tasks.alfrescoWar.archiveFile, configurations.alfrescoAmp)
+    doFirst {
+        java.io.File alfrescoJsrApiFile = project.zipTree(tasks.alfrescoWar.archiveFile)
+                .matching {
+                    include("WEB-INF/lib/jsr250-api-1.0.jar")
+                }
+                .singleFile
+
+        java.io.File ampJsrApiFile = project.zipTree(configurations.alfrescoAmp.singleFile)
+                .matching {
+                    include "lib/jsr250-api-1.0.jar"
+                }
+                .singleFile
+
+        println "Alfresco jsr250-api: ${alfrescoJsrApiFile}"
+        println "AMP jsr250-api: ${ampJsrApiFile}"
+
+        assert alfrescoJsrApiFile.bytes == ampJsrApiFile.bytes
+    }
+}


### PR DESCRIPTION
Overwriting files in an alfresco WAR with an AMP should work, also when using the `alfrescoWar` task.
It appears that this issue was already fixed as a side-effect of #220, where duplicates strategy was
changed from EXCLUDE to INCLUDE.

Fixes #229 