### PR TITLE
Add exception message showing cause of invalid AMP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 * [#201](https://github.com/xenit-eu/alfresco-docker-gradle-plugin/issues/201) - Make it possible to disable rewriting log4j.properties
+* [#227](https://github.com/xenit-eu/alfresco-docker-gradle-plugin/issues/227) - Improve message for `xyz.amp is not a valid AMP` exception
 
 ### Fixed
 

--- a/build.gradle
+++ b/build.gradle
@@ -129,6 +129,7 @@ dependencies {
     implementation 'com.bmuschko:gradle-docker-plugin:6.7.0'
     implementation 'com.avast.gradle:gradle-docker-compose-plugin:0.14.3'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
+    testImplementation 'org.hamcrest:hamcrest-core:1.3'
     testImplementation gradleTestKit()
     testImplementation "org.mockito:mockito-core:4.+"
     testImplementation 'com.github.stefanbirkner:system-rules:1.19.0'

--- a/src/main/java/eu/xenit/gradle/docker/alfresco/internal/amp/InvalidModuleException.java
+++ b/src/main/java/eu/xenit/gradle/docker/alfresco/internal/amp/InvalidModuleException.java
@@ -1,10 +1,24 @@
 package eu.xenit.gradle.docker.alfresco.internal.amp;
 
+import java.io.UncheckedIOException;
 import java.nio.file.Path;
+import org.alfresco.error.AlfrescoRuntimeException;
 
 public class InvalidModuleException extends ModuleException {
 
     InvalidModuleException(Path path, Throwable parent) {
-        super(path + " is not a valid AMP", parent);
+        super(createMessage(path, parent), parent);
+    }
+
+    InvalidModuleException(Path path, UncheckedIOException parent) {
+        super(createMessage(path, parent.getCause()), parent);
+    }
+
+    private static String createMessage(Path path, Throwable parent) {
+        return path + " is not a valid AMP: " + parent.toString();
+    }
+
+    InvalidModuleException(Path path, AlfrescoRuntimeException parent) {
+        super(path+" is not a valid AMP: "+parent.getMsgId(), parent);
     }
 }

--- a/src/main/java/eu/xenit/gradle/docker/alfresco/internal/amp/ModuleInformationAmp.java
+++ b/src/main/java/eu/xenit/gradle/docker/alfresco/internal/amp/ModuleInformationAmp.java
@@ -10,6 +10,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.util.Collections;
 import java.util.function.Function;
+import org.alfresco.error.AlfrescoRuntimeException;
 import org.alfresco.repo.module.tool.ModuleDetailsHelper;
 import org.alfresco.service.cmr.module.ModuleDetails;
 
@@ -57,7 +58,12 @@ class ModuleInformationAmp extends ModuleInformationFromModuleDetails {
                         throw new UncheckedIOException(e);
                     }
                 });
+            } catch(AlfrescoRuntimeException e) {
+                throw new InvalidModuleException(file.toPath(), e);
+            } catch(UncheckedIOException e) {
+                throw new InvalidModuleException(file.toPath(), e);
             } catch (Exception e) {
+                // Do not merge these catch-blocks: they each delegate to a different constructor!
                 throw new InvalidModuleException(file.toPath(), e);
             }
         }

--- a/src/test/java/eu/xenit/gradle/docker/alfresco/internal/amp/ModuleInformationAmpTest.java
+++ b/src/test/java/eu/xenit/gradle/docker/alfresco/internal/amp/ModuleInformationAmpTest.java
@@ -8,6 +8,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -58,7 +59,28 @@ public class ModuleInformationAmpTest {
             moduleInformation.getId();
         });
 
-        assertTrue(exception.getMessage().contains("test-jar.jar"));
+        assertTrue("Has the JAR file name", exception.getMessage().contains("test-jar.jar"));
+        assertTrue("Has the parent exception message", exception.getMessage().contains("NoSuchFileException: /module.properties"));
+    }
+
+    @Test
+    public void createFromInvalidAmp() throws IOException {
+
+        File jarFile = temporaryFolder.newFile("test-amp.amp");
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(new FileOutputStream(jarFile))) {
+            zipOutputStream.putNextEntry(new ZipEntry("module.properties"));
+            zipOutputStream.write("module.id=test-amp\n".getBytes(StandardCharsets.UTF_8));
+            zipOutputStream.closeEntry();
+        }
+
+        ModuleInformation moduleInformation = new ModuleInformationAmp(jarFile);
+
+        InvalidModuleException exception = assertThrows(InvalidModuleException.class, () -> {
+            moduleInformation.getId();
+        });
+
+        assertTrue("Has the AMP file name", exception.getMessage().contains("test-amp.amp"));
+        assertTrue("Has the error message", exception.getMessage().contains("The following module properties need to be defined"));
     }
 
 }

--- a/src/test/java/eu/xenit/gradle/docker/alfresco/internal/amp/ModuleInformationAmpTest.java
+++ b/src/test/java/eu/xenit/gradle/docker/alfresco/internal/amp/ModuleInformationAmpTest.java
@@ -1,5 +1,8 @@
 package eu.xenit.gradle.docker.alfresco.internal.amp;
 
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -60,7 +63,10 @@ public class ModuleInformationAmpTest {
         });
 
         assertTrue("Has the JAR file name", exception.getMessage().contains("test-jar.jar"));
-        assertTrue("Has the parent exception message", exception.getMessage().contains("NoSuchFileException: /module.properties"));
+        assertThat(exception.getMessage(), anyOf(
+                containsString("NoSuchFileException: /module.properties"),
+                containsString("NoSuchFileException: module.properties")
+        ));
     }
 
     @Test


### PR DESCRIPTION
Trying to install a JAR file as an AMP is not the only error that can
occur, people sometimes also try to install the AMP that they just
created, which may not be valid.

In that case, the real cause of the invalid AMP is hidden in the cause
chain, which is not shown by Gradle by default and is hidden behind
`--stacktrace`.

Fixes #227 