### PR TITLE
Add test for leanImage on a skeleton image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           java-version: 11
       - name: Pull docker images
-        run: 'parallel docker pull -- alfresco/alfresco-content-repository-community:6.0.7-ga tomcat:7-jre8 hello-world alpine:edge'
+        run: 'parallel docker pull -- xenit/alfresco-repository-skeleton:6.0 alfresco/alfresco-content-repository-community:6.0.7-ga tomcat:7-jre8 hello-world alpine:edge'
       - name: Check
         run: ./gradlew check -PintegrationTestGradleVersions=$TEST_GRADLE_VERSION
       - name: Upload reports

--- a/src/integrationTest/java/eu/xenit/gradle/testrunner/Reproductions.java
+++ b/src/integrationTest/java/eu/xenit/gradle/testrunner/Reproductions.java
@@ -182,4 +182,9 @@ public class Reproductions extends AbstractIntegrationTest {
     public void testIssue229() throws IOException {
         testProjectFolder(REPRODUCTIONS.resolve("issue-229"), ":integrationTest");
     }
+
+    @Test
+    public void testIssue230() throws IOException {
+        getGradleRunner(REPRODUCTIONS.resolve("issue-230"), ":buildDockerImage").buildAndFail();
+    }
 }

--- a/src/integrationTest/reproductions/issue-230/build.gradle
+++ b/src/integrationTest/reproductions/issue-230/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+    id 'eu.xenit.docker-alfresco'
+    id "eu.xenit.alfresco" version "1.1.0"
+}
+
+repositories {
+    mavenCentral()
+    alfrescoPublic()
+}
+
+dependencies {
+    baseAlfrescoWar "org.alfresco:content-services-community:6.0.a@war"
+}
+
+dockerBuild {
+    alfresco {
+        baseImage = "xenit/alfresco-repository-skeleton:6.0"
+        leanImage = true
+    }
+}
+


### PR DESCRIPTION
leanImage=true disables injecting a full WAR into a docker image.
However, a skeleton image is an image without an Alfresco WAR inside, so
injecting only the contents of applied amps, DEs and SMs will not work.

Although this is completely user error, we try to save them some
debugging time by failing the image build when we detect that no war is
present (indicated by no version.properties file being present)

Fixes #230 