### PR TITLE
Activate workaround for docker consecutive copy bug by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+* [#275](https://github.com/xenit-eu/alfresco-docker-gradle-plugin/pull/275) - Activate workaround for docker consecutive copy bug by default
+
 ## Version 5.3.1 - 2021-12-17
 
 ### Added

--- a/src/integrationTest/reproductions/issue-176-mitigation/gradle.properties
+++ b/src/integrationTest/reproductions/issue-176-mitigation/gradle.properties
@@ -1,1 +1,0 @@
-eu.xenit.docker.flags.workaround-dockerd-consecutive-copy-bug=true

--- a/src/integrationTest/reproductions/remove-empty-commands/build.gradle
+++ b/src/integrationTest/reproductions/remove-empty-commands/build.gradle
@@ -13,6 +13,7 @@ createDockerFile {
         assert textInstructions.equals([
                 'FROM tomcat:7-jre8',
                 'COPY copyFile/1/ copyFile/2/ copyFile/3/ copyFile/4/ copyFile/5/ copyFile/6/ /usr/local/tomcat/webapps/alfresco/',
+                'RUN true', // Inserted by docker consecutive copy bug mitigation
                 'COPY copyFile/7/ copyFile/8/ copyFile/9/ copyFile/10/ copyFile/11/ /usr/local/tomcat/webapps/share/'
         ])
     }

--- a/src/main/java/eu/xenit/gradle/docker/core/DockerPlugin.java
+++ b/src/main/java/eu/xenit/gradle/docker/core/DockerPlugin.java
@@ -30,12 +30,6 @@ public class DockerPlugin implements Plugin<Project> {
         return dockerExtension;
     }
 
-    private static boolean readPropertyFlag(Project project, String property) {
-        return Optional.ofNullable(project.findProperty(property))
-                .map(Object::toString)
-                .map(Boolean::parseBoolean)
-                .orElse(false);
-    }
 
     @Override
     public void apply(Project project) {
@@ -59,9 +53,7 @@ public class DockerPlugin implements Plugin<Project> {
                 .register("createDockerFile", DockerfileWithCopyTask.class, dockerfile -> {
                     dockerfile.setDescription("Create a Dockerfile");
                     dockerfile.setGroup(TASK_GROUP);
-                    if (readPropertyFlag(project, WorkaroundDockerdConsecutiveCopyBugAction.FEATURE_FLAG)) {
-                        dockerfile.doFirst("Mitigate Docker COPY bug", new WorkaroundDockerdConsecutiveCopyBugAction());
-                    }
+                    dockerfile.doFirst("Mitigate Docker COPY bug", new WorkaroundDockerdConsecutiveCopyBugAction());
                     dockerfile.doFirst("Consolidate COPY instructions", new ConsolidateFileCopyInstructionsAction());
                 });
         dockerExtension.getDockerFile().convention(dockerfileProvider.flatMap(Dockerfile::getDestFile));


### PR DESCRIPTION
We have now hit this issue a couple of times, because the workaround is not enabled by default.

Every time we hit the bug, enabling the feature flag was enough to solve it, without it making things worse.

We keep the feature flag just in case we bump into a case where it breaks.
