### PR TITLE
Autobuild latest gradle versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,6 @@ jobs:
   build:
     name: "build"
     runs-on: ubuntu-latest
-    env:
-      TEST_GRADLE_VERSION: 6.7
     steps:
       - uses: actions/checkout@v2
         with:
@@ -24,7 +22,7 @@ jobs:
       - name: Pull docker images
         run: 'parallel docker pull -- xenit/alfresco-repository-skeleton:6.0 alfresco/alfresco-content-repository-community:6.0.7-ga tomcat:7-jre8 hello-world alpine:edge'
       - name: Check
-        run: ./gradlew check -PintegrationTestGradleVersions=$TEST_GRADLE_VERSION
+        run: ./gradlew check -PintegrationTestScope=0
       - name: Upload reports
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2
@@ -36,13 +34,13 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ github.token }}
-        run: ./gradlew sonarqube -Dsonar.projectKey=xenit-eu_alfresco-docker-gradle-plugin -Dsonar.organization=xenit-eu -Dsonar.host.url=https://sonarcloud.io -PintegrationTestGradleVersions=$TEST_GRADLE_VERSION
+        run: ./gradlew sonarqube -Dsonar.projectKey=xenit-eu_alfresco-docker-gradle-plugin -Dsonar.organization=xenit-eu -Dsonar.host.url=https://sonarcloud.io -PintegrationTestScope=0
       - name: Publish
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         env:
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PLUGINS_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PLUGINS_PUBLISH_SECRET }}
-        run: ./gradlew check -PintegrationTestMajorsOnly=true publishPlugins -Pgradle.publish.key=$GRADLE_PUBLISH_KEY -Pgradle.publish.secret=$GRADLE_PUBLISH_SECRET
+        run: ./gradlew publishPlugins -Pgradle.publish.key=$GRADLE_PUBLISH_KEY -Pgradle.publish.secret=$GRADLE_PUBLISH_SECRET
   integration-test:
     name: "integration-test (slice=${{ matrix.slice }})"
     runs-on: ubuntu-latest
@@ -64,7 +62,7 @@ jobs:
       - name: Pull docker images
         run: 'parallel docker pull -- alfresco/alfresco-content-repository-community:6.0.7-ga tomcat:7-jre8 hello-world alpine:edge'
       - name: Check
-        run: ./gradlew check -PintegrationTestSlice.index=${{ matrix.slice }} -PintegrationTestSlice.total=5
+        run: ./gradlew check -PintegrationTestSlice.index=${{ matrix.slice }} -PintegrationTestSlice.total=5 -PintegrationTestScope=2
       - name: Upload reports
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,18 +42,18 @@ jobs:
         env:
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PLUGINS_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PLUGINS_PUBLISH_SECRET }}
-        run: ./gradlew publishPlugins -Pgradle.publish.key=$GRADLE_PUBLISH_KEY -Pgradle.publish.secret=$GRADLE_PUBLISH_SECRET
+        run: ./gradlew check -PintegrationTestMajorsOnly=true publishPlugins -Pgradle.publish.key=$GRADLE_PUBLISH_KEY -Pgradle.publish.secret=$GRADLE_PUBLISH_SECRET
   integration-test:
-    name: "integration-test (gradle-versions=${{ matrix.gradle-versions}})"
+    name: "integration-test (slice=${{ matrix.slice }})"
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gradle-versions:
-          - 5.6
-          - 6.0,6.1,6.2
-          - 6.3,6.4,6.5
-          - 6.6,6.7,6.8
-          - 7.0,7.1,7.2
+        slice:
+          - 0
+          - 1
+          - 2
+          - 3
+          - 4
     steps:
       - uses: actions/checkout@v2
         with:
@@ -64,10 +64,10 @@ jobs:
       - name: Pull docker images
         run: 'parallel docker pull -- alfresco/alfresco-content-repository-community:6.0.7-ga tomcat:7-jre8 hello-world alpine:edge'
       - name: Check
-        run: ./gradlew check -PintegrationTestGradleVersions=${{ matrix.gradle-versions }}
+        run: ./gradlew check -PintegrationTestSlice.index=${{ matrix.slice }} -PintegrationTestSlice.total=5
       - name: Upload reports
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2
         with:
-          name: reports-integration-test-${{ matrix.gradle-versions }}
+          name: reports-integration-test-${{ matrix.slice }}
           path: build/reports

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,4 +18,4 @@ install:
 build_script:
     - cmd: gradlew assemble
 test_script:
-    - cmd: gradlew check -i -PintegrationTestGradleVersions=6.4
+    - cmd: gradlew check -i -PintegrationTestScope=0

--- a/build.gradle
+++ b/build.gradle
@@ -133,6 +133,8 @@ dependencies {
     testImplementation gradleTestKit()
     testImplementation "org.mockito:mockito-core:4.+"
     testImplementation 'com.github.stefanbirkner:system-rules:1.19.0'
+
+    integrationTestImplementation 'com.fasterxml.jackson.core:jackson-databind:2.10.3'
 }
 
 
@@ -180,6 +182,9 @@ task integrationTest(type: Test, group: "verification") {
             filter.includeTestsMatching("*[Gradle v${version}.*]")
         })
     }
+    systemProperty "eu.xenit.gradle.integration.majorsOnly", project.findProperty("integrationTestMajorsOnly") ?: "false"
+    systemProperty "eu.xenit.gradle.integration.slice.index", project.findProperty("integrationTestSlice.index") ?: "0"
+    systemProperty "eu.xenit.gradle.integration.slice.total", project.findProperty("integrationTestSlice.total") ?: "1"
     doFirst {
         if (gradle.startParameter.offline) {
             systemProperty "eu.xenit.gradle.integration.useGradleVersion", GradleVersion.current().version

--- a/build.gradle
+++ b/build.gradle
@@ -168,21 +168,14 @@ import org.gradle.util.GradleVersion
 
 task integrationTest(type: Test, group: "verification") {
     useJUnit()
-    if (project.hasProperty("integrationTestGradleVersions")) {
-        // This is used for sharding integration tests across different gradle versions
-        // to avoid a timeout on travis because the total build takes too long.
-        // See also the .travis.yml file
-        project.property("integrationTestGradleVersions").tokenize(",").forEach({ version ->
-            // The versions specified in `integrationTestGradleVersions` are major.minor.
-            // We only want it to match those, and eventual patches to those versions.
-            // In particular, we want 4.1 to match 4.1.2, but not 4.10.
-            // Since there is only one test parameter for every version, either the first
-            // pattern matches major.minor, or the second pattern matches major.minor.patch
-            filter.includeTestsMatching("*[Gradle v${version}]")
-            filter.includeTestsMatching("*[Gradle v${version}.*]")
-        })
-    }
-    systemProperty "eu.xenit.gradle.integration.majorsOnly", project.findProperty("integrationTestMajorsOnly") ?: "false"
+    /**
+     * integrationTestScope selects which Gradle versions get tested against
+     * A scope of 0 only tests the earliest and latest version and gives quick feedback
+     * A scope of 1 additionally tests the earliest and latest version of every major release
+     * A scope of 2 additionally tests the latest version of every minor release
+     * A scope of 3 tests all patch releases"
+     */
+    systemProperty "eu.xenit.gradle.integration.scope", project.findProperty("integrationTestScope") ?: (ci.isCi()?"2":"0")
     systemProperty "eu.xenit.gradle.integration.slice.index", project.findProperty("integrationTestSlice.index") ?: "0"
     systemProperty "eu.xenit.gradle.integration.slice.total", project.findProperty("integrationTestSlice.total") ?: "1"
     doFirst {

--- a/src/integrationTest/java/eu/xenit/gradle/testrunner/AbstractIntegrationTest.java
+++ b/src/integrationTest/java/eu/xenit/gradle/testrunner/AbstractIntegrationTest.java
@@ -52,16 +52,16 @@ public abstract class AbstractIntegrationTest {
             });
         }
 
-        boolean majorsOnly = Boolean.getBoolean("eu.xenit.gradle.integration.majorsOnly");
+        int scope = Integer.parseUnsignedInt(System.getProperty("eu.xenit.gradle.integration.scope", "2"));
         List<String[]> versionsToBuild = VersionFetcher.fetchVersionSeries()
                 // Only release versions >= 5.6
                 .map(series -> series.filter(VersionFetcher::isRelease)
                         .filter(VersionFetcher.greaterThanOrEqual("5.6")))
                 .filter(series -> !series.isEmpty())
-                // When selecting only majors, select the series with only the major version component
-                .filter(series -> !majorsOnly || series.getSeriesPriority() == 1)
-                // For series with only the major version component, select the first and last version, for series with the minor version component, only select the last version
-                .flatMap(series -> series.getSeriesPriority() == 1 ? Stream.of(series.getLowestVersion(), series.getHighestVersion()): Stream.of(
+                // Select only the series within a certain scope
+                .filter(series -> series.getSeriesPriority() <= scope)
+                // For series with none, or only the major version component, select the first and last version, for series with the minor version component, only select the last version
+                .flatMap(series -> series.getSeriesPriority() <= 1 ? Stream.of(series.getLowestVersion(), series.getHighestVersion()): Stream.of(
                         series.getHighestVersion()))
                 // Collect to a set to deduplicate versions
                 .collect(Collectors.toSet())

--- a/src/integrationTest/java/eu/xenit/gradle/testrunner/AbstractIntegrationTest.java
+++ b/src/integrationTest/java/eu/xenit/gradle/testrunner/AbstractIntegrationTest.java
@@ -3,22 +3,28 @@ package eu.xenit.gradle.testrunner;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import eu.xenit.gradle.testrunner.versions.GradleVersionSpec;
+import eu.xenit.gradle.testrunner.versions.VersionFetcher;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
+import org.gradle.util.GradleVersion;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
@@ -36,28 +42,71 @@ public abstract class AbstractIntegrationTest {
     public String gradleVersion;
 
     @Parameters(name = "Gradle v{0}")
-    public static Collection<Object[]> testData() {
+    public static List<String[]> testData() {
         String forceGradleVersion = System.getProperty("eu.xenit.gradle.integration.useGradleVersion");
         if (forceGradleVersion != null) {
-            return Arrays.asList(new Object[][]{
+            return Arrays.asList(new String[][]{
                     {forceGradleVersion},
             });
         }
-        return Arrays.asList(new Object[][]{
-                {"7.2"},
-                {"7.1"},
-                {"7.0"},
-                {"6.8.3"},
-                {"6.7.1"},
-                {"6.6.1"},
-                {"6.5.1"},
-                {"6.4.1"},
-                {"6.3"},
-                {"6.2.2"},
-                {"6.1.1"},
-                {"6.0.1"},
-                {"5.6.4"},
-        });
+
+        boolean majorsOnly = Boolean.getBoolean("eu.xenit.gradle.integration.majorsOnly");
+        Comparator<GradleVersionSpec> byVersionNumber = Comparator.comparing(versionSpec -> GradleVersion.version(versionSpec.getVersion()));
+        List<GradleVersionSpec> fetchedVersions = VersionFetcher.fetchVersions()
+                .filter(VersionFetcher::isRelease)
+                .filter(VersionFetcher.greaterThan("5.6"))
+                .sorted(byVersionNumber)
+                .collect(Collectors.toList());
+
+        Map<String, List<GradleVersionSpec>> versionsByMinor = new HashMap<>();
+
+        for (GradleVersionSpec versionSpec : fetchedVersions) {
+            String[] versionParts = GradleVersion.version(versionSpec.getVersion()).getBaseVersion().getVersion().split("\\.");
+            String versionKey = majorsOnly?versionParts[0]:(versionParts[0]+"."+versionParts[1]);
+            if(versionsByMinor.containsKey(versionKey)) {
+                versionsByMinor.get(versionKey).add(versionSpec);
+            } else {
+                versionsByMinor.put(versionKey, new ArrayList<>(Collections.singletonList(versionSpec)));
+                if(majorsOnly) {
+                    versionsByMinor.put(versionKey + "-lowest", Collections.singletonList(versionSpec));
+                }
+            }
+        }
+
+
+        List<String[]> versionsToBuild = versionsByMinor.values()
+                .stream()
+                .map(versions -> versions.stream()
+                        // Find latest patch version
+                        .sorted(byVersionNumber.reversed())
+                        .findFirst()
+                        .orElse(null)
+                )
+                .filter(Objects::nonNull)
+                .sorted(byVersionNumber)
+                .map(GradleVersionSpec::getVersion)
+                .map(version -> new String[]{version})
+                .collect(Collectors.toList());
+
+        List<String[]> slicedVersions = slice(versionsToBuild);
+        System.out.println(slicedVersions.stream()
+                .map(i -> i[0])
+                .collect(Collectors.joining(", ", "Running test on versions: ", "")));
+        return slicedVersions;
+    }
+
+    private static <T> List<T> slice(List<T> items) {
+        try {
+            int sliceTotal = Integer.parseUnsignedInt(
+                    System.getProperty("eu.xenit.gradle.integration.slice.total", "1"));
+            int sliceIndex = Integer.parseUnsignedInt(
+                    System.getProperty("eu.xenit.gradle.integration.slice.index", "0"));
+            int itemsPerSlice = (int)Math.ceil(items.size()/(float)sliceTotal);
+            System.out.println("Executing slice "+(sliceIndex+1)+"/"+sliceTotal+ " with "+itemsPerSlice+" items per slice");
+            return items.subList(itemsPerSlice*sliceIndex, Math.min(itemsPerSlice*(sliceIndex+1), items.size()));
+        } catch (NumberFormatException e) {
+            return items;
+        }
     }
 
 

--- a/src/integrationTest/java/eu/xenit/gradle/testrunner/versions/GradleVersionSeries.java
+++ b/src/integrationTest/java/eu/xenit/gradle/testrunner/versions/GradleVersionSeries.java
@@ -1,0 +1,48 @@
+package eu.xenit.gradle.testrunner.versions;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public class GradleVersionSeries {
+    private final String series;
+    private final Set<GradleVersionSpec> versionSpecs;
+
+    public GradleVersionSeries(String series, Set<GradleVersionSpec> versionSpecs) {
+        this.series = series;
+        this.versionSpecs = versionSpecs;
+    }
+
+    public static GradleVersionSeries extract(String series, Collection<GradleVersionSpec> versionSpecs) {
+        Set<GradleVersionSpec> extractedVersions = versionSpecs.stream()
+                .filter(spec -> spec.getVersionSeries().contains(series))
+                .collect(Collectors.toSet());
+        return new GradleVersionSeries(series, extractedVersions);
+    }
+
+    public int getSeriesPriority() {
+        return series.split("\\.").length;
+    }
+
+    public GradleVersionSpec getLowestVersion() {
+        return versionSpecs.stream()
+                .min(GradleVersionSpec.BY_VERSION_NUMBER)
+                .orElse(null);
+    }
+
+    public GradleVersionSpec getHighestVersion() {
+        return versionSpecs.stream()
+                .max(GradleVersionSpec.BY_VERSION_NUMBER)
+                .orElse(null);
+    }
+
+    public GradleVersionSeries filter(Predicate<GradleVersionSpec> predicate) {
+        return new GradleVersionSeries(series, versionSpecs.stream().filter(predicate).collect(Collectors.toSet()));
+    }
+
+    public boolean isEmpty() {
+        return versionSpecs.isEmpty();
+    }
+
+}

--- a/src/integrationTest/java/eu/xenit/gradle/testrunner/versions/GradleVersionSeries.java
+++ b/src/integrationTest/java/eu/xenit/gradle/testrunner/versions/GradleVersionSeries.java
@@ -22,6 +22,9 @@ public class GradleVersionSeries {
     }
 
     public int getSeriesPriority() {
+        if(series.isEmpty()) {
+            return 0;
+        }
         return series.split("\\.").length;
     }
 

--- a/src/integrationTest/java/eu/xenit/gradle/testrunner/versions/GradleVersionSpec.java
+++ b/src/integrationTest/java/eu/xenit/gradle/testrunner/versions/GradleVersionSpec.java
@@ -1,11 +1,17 @@
 package eu.xenit.gradle.testrunner.versions;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
 import org.gradle.util.GradleVersion;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class GradleVersionSpec {
+    public static final Comparator<GradleVersionSpec> BY_VERSION_NUMBER = Comparator.comparing(versionSpec -> GradleVersion.version(versionSpec.getVersion()));
+
     private String version;
     private boolean snapshot;
     private boolean broken;
@@ -13,6 +19,22 @@ public class GradleVersionSpec {
 
     public String getVersion() {
         return version;
+    }
+
+    public Set<String> getVersionSeries() {
+        String[] parts = GradleVersion.version(version).getBaseVersion().getVersion().split("\\.");
+
+        Set<String> series = new HashSet<>();
+
+        for (int i = 0; i < parts.length; i++) {
+            String serie = "";
+            for (int j = 0; j <= i; j++) {
+                serie+=parts[j]+".";
+            }
+            series.add(serie.substring(0, Math.max(serie.length()-1, 0)));
+        }
+
+        return Collections.unmodifiableSet(series);
     }
 
     public void setVersion(String version) {
@@ -41,5 +63,23 @@ public class GradleVersionSpec {
 
     public void setRcFor(String rcFor) {
         this.rcFor = rcFor;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GradleVersionSpec that = (GradleVersionSpec) o;
+        return snapshot == that.snapshot && broken == that.broken && version.equals(that.version) && rcFor.equals(
+                that.rcFor);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(version, snapshot, broken, rcFor);
     }
 }

--- a/src/integrationTest/java/eu/xenit/gradle/testrunner/versions/GradleVersionSpec.java
+++ b/src/integrationTest/java/eu/xenit/gradle/testrunner/versions/GradleVersionSpec.java
@@ -33,6 +33,7 @@ public class GradleVersionSpec {
             }
             series.add(serie.substring(0, Math.max(serie.length()-1, 0)));
         }
+        series.add("");
 
         return Collections.unmodifiableSet(series);
     }

--- a/src/integrationTest/java/eu/xenit/gradle/testrunner/versions/GradleVersionSpec.java
+++ b/src/integrationTest/java/eu/xenit/gradle/testrunner/versions/GradleVersionSpec.java
@@ -1,0 +1,45 @@
+package eu.xenit.gradle.testrunner.versions;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Comparator;
+import org.gradle.util.GradleVersion;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GradleVersionSpec {
+    private String version;
+    private boolean snapshot;
+    private boolean broken;
+    private String rcFor;
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public boolean isSnapshot() {
+        return snapshot;
+    }
+
+    public void setSnapshot(boolean snapshot) {
+        this.snapshot = snapshot;
+    }
+
+    public boolean isBroken() {
+        return broken;
+    }
+
+    public void setBroken(boolean broken) {
+        this.broken = broken;
+    }
+
+    public String getRcFor() {
+        return rcFor;
+    }
+
+    public void setRcFor(String rcFor) {
+        this.rcFor = rcFor;
+    }
+}

--- a/src/integrationTest/java/eu/xenit/gradle/testrunner/versions/VersionFetcher.java
+++ b/src/integrationTest/java/eu/xenit/gradle/testrunner/versions/VersionFetcher.java
@@ -54,8 +54,7 @@ public class VersionFetcher {
         }
 
         return versionSeries.stream()
-                .map(series -> GradleVersionSeries.extract(series, versions))
-                .filter(series -> series.getSeriesPriority() <= 2);
+                .map(series -> GradleVersionSeries.extract(series, versions));
     }
 
 }

--- a/src/integrationTest/java/eu/xenit/gradle/testrunner/versions/VersionFetcher.java
+++ b/src/integrationTest/java/eu/xenit/gradle/testrunner/versions/VersionFetcher.java
@@ -8,9 +8,12 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.gradle.util.GradleVersion;
 
@@ -33,22 +36,26 @@ public class VersionFetcher {
         return !versionSpec.isSnapshot() && versionSpec.getRcFor().isEmpty() && Objects.equals(gradleVersion.getBaseVersion(), gradleVersion);
     }
 
-    public static boolean isBroken(GradleVersionSpec versionSpec) {
-        return versionSpec.isBroken();
-    }
-
-    public static Predicate<GradleVersionSpec> greaterThan(String version) {
-        return versionSpec -> GradleVersion.version(versionSpec.getVersion()).compareTo(GradleVersion.version(version)) > 0;
-    }
-
-    public static boolean firstPointRelease(GradleVersionSpec versionSpec) {
-        return GradleVersion.version(versionSpec.getVersion()).getBaseVersion().getVersion().endsWith(".0");
+    public static Predicate<GradleVersionSpec> greaterThanOrEqual(String version) {
+        return versionSpec -> GradleVersion.version(versionSpec.getVersion()).compareTo(GradleVersion.version(version)) >= 0;
     }
 
     public static Stream<GradleVersionSpec> fetchVersions() {
         return fetchAllVersions()
                 .stream()
                 .filter(((Predicate<? super GradleVersionSpec>) GradleVersionSpec::isBroken).negate());
+    }
+
+    public static Stream<GradleVersionSeries> fetchVersionSeries() {
+        List<GradleVersionSpec> versions =  fetchVersions().collect(Collectors.toList());
+        Set<String> versionSeries = new HashSet<>();
+        for (GradleVersionSpec version : versions) {
+            versionSeries.addAll(version.getVersionSeries());
+        }
+
+        return versionSeries.stream()
+                .map(series -> GradleVersionSeries.extract(series, versions))
+                .filter(series -> series.getSeriesPriority() <= 2);
     }
 
 }

--- a/src/integrationTest/java/eu/xenit/gradle/testrunner/versions/VersionFetcher.java
+++ b/src/integrationTest/java/eu/xenit/gradle/testrunner/versions/VersionFetcher.java
@@ -1,0 +1,54 @@
+package eu.xenit.gradle.testrunner.versions;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.CollectionType;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+import org.gradle.util.GradleVersion;
+
+public class VersionFetcher {
+    private static List<GradleVersionSpec> fetchAllVersions() {
+        ObjectMapper mapper = new ObjectMapper();
+
+        try {
+            CollectionType type = mapper.getTypeFactory().constructCollectionType(List.class, GradleVersionSpec.class);
+            return mapper.readerFor(type).readValue(new URL("https://services.gradle.org/versions/all"));
+        } catch (MalformedURLException | JsonMappingException | JsonParseException e) {
+            throw new RuntimeException(e);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public static boolean isRelease(GradleVersionSpec versionSpec) {
+        GradleVersion gradleVersion = GradleVersion.version(versionSpec.getVersion());
+        return !versionSpec.isSnapshot() && versionSpec.getRcFor().isEmpty() && Objects.equals(gradleVersion.getBaseVersion(), gradleVersion);
+    }
+
+    public static boolean isBroken(GradleVersionSpec versionSpec) {
+        return versionSpec.isBroken();
+    }
+
+    public static Predicate<GradleVersionSpec> greaterThan(String version) {
+        return versionSpec -> GradleVersion.version(versionSpec.getVersion()).compareTo(GradleVersion.version(version)) > 0;
+    }
+
+    public static boolean firstPointRelease(GradleVersionSpec versionSpec) {
+        return GradleVersion.version(versionSpec.getVersion()).getBaseVersion().getVersion().endsWith(".0");
+    }
+
+    public static Stream<GradleVersionSpec> fetchVersions() {
+        return fetchAllVersions()
+                .stream()
+                .filter(((Predicate<? super GradleVersionSpec>) GradleVersionSpec::isBroken).negate());
+    }
+
+}


### PR DESCRIPTION
Extend the integration test logic to automatically fetch versions from Gradle.

For integration tests: Filter the list down to supported versions, and only run the highest of every minor version.
For the main test: Run the lowest and highest version.

Instead of based on hardcoded version numbers, the integration tests are split into slices, each having approximately the same number of versions to run tests for.