### PR TITLE
Move reckon to settings plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ plugins {
     id "idea"
     id "jacoco"
     id "com.gradle.plugin-publish" version "1.2.1"
-    id 'org.ajoberstar.reckon' version "0.18.3"
     id 'com.github.johnrengelman.shadow' version '7.1.2' apply false
     id "org.sonarqube" version "5.1.0.4882"
     id "be.vbgn.ci-detect" version "0.5.0"
@@ -112,11 +111,6 @@ gradlePlugin {
         }
     }
 
-}
-
-reckon {
-    scopeFromProp()
-    snapshotFromProp()
 }
 
 repositories {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,12 @@
+plugins {
+    id 'org.ajoberstar.reckon.settings' version "0.18.3"
+}
+
 rootProject.name = 'alfresco-docker-plugin'
+
+reckon {
+    defaultInferredScope = 'patch'
+    snapshots()
+    scopeCalc = calcScopeFromProp()
+    stageCalc = calcStageFromProp()
+}


### PR DESCRIPTION
There is something that consumes the version before reckon gets a chance to set it when using reckon in build.gradle

To fix that; move to the reckon settings plugin
